### PR TITLE
update "ggrs_socket" feature and matchbox_demo to ggrs 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
@@ -575,13 +575,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_ggrs"
-version = "0.1.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16afceed8bd55b372711b870ec33caa2d2c901b708490674455088e2b167f667"
+checksum = "8f07f22e1afab73629dd296ba65e2ea45f1ba0712b762eb157be7287ee604450"
 dependencies = [
  "bevy",
+ "bytemuck",
  "ggrs",
  "instant",
+ "log",
 ]
 
 [[package]]
@@ -1027,9 +1029,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array",
 ]
@@ -1241,7 +1243,7 @@ dependencies = [
  "bitflags",
  "block",
  "cocoa-foundation",
- "core-foundation 0.9.2",
+ "core-foundation 0.9.3",
  "core-graphics 0.22.3",
  "foreign-types",
  "libc",
@@ -1256,7 +1258,7 @@ checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
 dependencies = [
  "bitflags",
  "block",
- "core-foundation 0.9.2",
+ "core-foundation 0.9.3",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -1332,9 +1334,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys 0.8.3",
  "libc",
@@ -1371,7 +1373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.2",
+ "core-foundation 0.9.3",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -1384,7 +1386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.2",
+ "core-foundation 0.9.3",
  "foreign-types",
  "libc",
 ]
@@ -1434,9 +1436,9 @@ checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
 
 [[package]]
 name = "crc32fast"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2209c310e29876f7f0b2721e7e26b84aff178aa3da5d091f9bfbf47669e60e3"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1453,9 +1455,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
@@ -1463,9 +1465,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
+checksum = "a4600d695eb3f6ce1cd44e6e291adceb2cc3ab12f20a33777ecd0bf6eba34e06"
 dependencies = [
  "generic-array",
 ]
@@ -1689,7 +1691,7 @@ dependencies = [
  "nom 7.1.0",
  "num-bigint",
  "num-traits",
- "rusticata-macros 4.0.0",
+ "rusticata-macros 4.1.0",
 ]
 
 [[package]]
@@ -1734,13 +1736,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
+checksum = "8cb780dce4f9a8f5c087362b3a4595936b2019e7c8b30f2c3e9a7e94e6ae9837"
 dependencies = [
- "block-buffer 0.10.0",
+ "block-buffer 0.10.2",
  "crypto-common",
- "generic-array",
 ]
 
 [[package]]
@@ -1938,9 +1939,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1953,9 +1954,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1963,15 +1964,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1980,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-lite"
@@ -2001,9 +2002,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2012,15 +2013,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-timer"
@@ -2034,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2095,12 +2096,13 @@ dependencies = [
 
 [[package]]
 name = "ggrs"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336c4728ab8dca8317120a377948d2e77131a9421e5c4139fc0844937274568f"
+checksum = "f9ff061418aad1227875f39b777e3700ec79612d2d630a4ed5a30baaf99763ab"
 dependencies = [
  "bincode",
  "bitfield-rle",
+ "bytemuck",
  "instant",
  "js-sys",
  "parking_lot",
@@ -2305,9 +2307,9 @@ dependencies = [
 
 [[package]]
 name = "headers"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84c647447a07ca16f5fbd05b633e535cc41a08d2d74ab1e08648df53be9cb89"
+checksum = "4cff78e5788be1e0ab65b04d306b2ed5092c815ec97ec70f4ebd5aee158aa55d"
 dependencies = [
  "base64",
  "bitflags",
@@ -2316,7 +2318,7 @@ dependencies = [
  "http",
  "httpdate",
  "mime",
- "sha-1",
+ "sha-1 0.10.0",
 ]
 
 [[package]]
@@ -2393,7 +2395,7 @@ checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.1",
+ "itoa",
 ]
 
 [[package]]
@@ -2409,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
 
 [[package]]
 name = "httpdate"
@@ -2430,9 +2432,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.16"
+version = "0.14.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
+checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2443,7 +2445,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 0.4.8",
+ "itoa",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2542,12 +2544,6 @@ name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -2664,6 +2660,7 @@ version = "0.2.0"
 dependencies = [
  "bevy",
  "bevy_ggrs",
+ "bytemuck",
  "clap",
  "console_error_panic_hook",
  "console_log",
@@ -2754,7 +2751,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6a38fc55c8bbc10058782919516f88826e70320db6d206aebc49611d24216ae"
 dependencies = [
- "digest 0.10.1",
+ "digest 0.10.2",
 ]
 
 [[package]]
@@ -3014,9 +3011,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
 ]
@@ -3668,9 +3665,9 @@ dependencies = [
 
 [[package]]
 name = "rusticata-macros"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c52377bb2288aa522a0c8208947fada1e0c76397f108cc08f57efe6077b50d"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
  "nom 7.1.0",
 ]
@@ -3742,9 +3739,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+checksum = "0486718e92ec9a68fbed73bb5ef687d71103b142595b406835649bebd33f72c7"
 
 [[package]]
 name = "send_wrapper"
@@ -3780,11 +3777,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
- "itoa 1.0.1",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -3807,7 +3804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.1",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -3823,6 +3820,17 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.2",
 ]
 
 [[package]]
@@ -3846,7 +3854,7 @@ checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.1",
+ "digest 0.10.2",
 ]
 
 [[package]]
@@ -4241,9 +4249,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5312f325fe3588e277415f5a6cca1f4ccad0f248c4cd5a4bd33032d7286abc22"
+checksum = "74786ce43333fcf51efe947aed9718fbe46d5c7328ec3f1029e818083966d9aa"
 dependencies = [
  "ansi_term",
  "lazy_static",
@@ -4293,7 +4301,7 @@ dependencies = [
  "httparse",
  "log",
  "rand",
- "sha-1",
+ "sha-1 0.9.8",
  "thiserror",
  "url",
  "utf-8",
@@ -4312,7 +4320,7 @@ dependencies = [
  "httparse",
  "log",
  "rand",
- "sha-1",
+ "sha-1 0.9.8",
  "thiserror",
  "url",
  "utf-8",
@@ -4768,7 +4776,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_derive",
- "sha-1",
+ "sha-1 0.9.8",
  "sha2 0.9.9",
  "signature",
  "subtle",
@@ -4863,7 +4871,7 @@ dependencies = [
  "log",
  "rtcp",
  "rtp",
- "sha-1",
+ "sha-1 0.9.8",
  "subtle",
  "thiserror",
  "tokio",
@@ -5031,7 +5039,7 @@ checksum = "9b43cc931d58b99461188607efd7acb2a093e65fc621f54cad78517a6063e73a"
 dependencies = [
  "bitflags",
  "cocoa",
- "core-foundation 0.9.2",
+ "core-foundation 0.9.3",
  "core-graphics 0.22.3",
  "core-video-sys",
  "dispatch",
@@ -5134,7 +5142,7 @@ dependencies = [
  "nom 7.1.0",
  "oid-registry 0.2.0",
  "ring",
- "rusticata-macros 4.0.0",
+ "rusticata-macros 4.1.0",
  "thiserror",
 ]
 

--- a/matchbox_demo/Cargo.toml
+++ b/matchbox_demo/Cargo.toml
@@ -28,8 +28,9 @@ wasm-bindgen = "0.2"
 [dependencies]
 matchbox_socket = { path = "../matchbox_socket", features = ["ggrs-socket"] }
 bevy = { version = "0.6", default-features = false }
-ggrs = "0.8"
-bevy_ggrs = "=0.1.3"
+ggrs = "0.9"
+bevy_ggrs = "0.9"
+bytemuck = { version = "1.7", features=["derive"]}
 clap = { version = "3.0", features = ["derive"] }
 serde = "1.0"
 winit = "0.26.0"

--- a/matchbox_demo/README.md
+++ b/matchbox_demo/README.md
@@ -22,7 +22,7 @@ cargo install wasm-server-runner
 ## Build and serve
 
 ```
-cargo run --release --target wasm32-unknown-unknown
+cargo run --target wasm32-unknown-unknown
 ```
 
 then point your browser to http://127.0.0.1:1334/

--- a/matchbox_demo/README.md
+++ b/matchbox_demo/README.md
@@ -22,7 +22,7 @@ cargo install wasm-server-runner
 ## Build and serve
 
 ```
-cargo run --target wasm32-unknown-unknown
+cargo run --release --target wasm32-unknown-unknown
 ```
 
 then point your browser to http://127.0.0.1:1334/

--- a/matchbox_demo/src/main.rs
+++ b/matchbox_demo/src/main.rs
@@ -54,7 +54,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         // Some of our systems need the query parameters
         .insert_resource(args)
-        .insert_resource(FrameCount::default())
+        .init_resource::<FrameCount>()
         .add_state(AppState::Lobby)
         .add_system_set(
             SystemSet::on_enter(AppState::Lobby)

--- a/matchbox_socket/Cargo.toml
+++ b/matchbox_socket/Cargo.toml
@@ -25,7 +25,7 @@ uuid = { version = "0.8", default-features = false, features = ["v4", "wasm-bind
 log = { version = "0.4", default-features = false }
 
 # ggrs-socket
-ggrs = { version = "0.8", default-features = false, optional = true }
+ggrs = { version = "0.9", default-features = false, optional = true }
 bincode = { version = "1.3", default-features = false, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/matchbox_socket/src/ggrs_socket.rs
+++ b/matchbox_socket/src/ggrs_socket.rs
@@ -1,59 +1,34 @@
-use ggrs::{PlayerType, UdpMessage};
-use std::{
-    collections::{hash_map::DefaultHasher, HashMap},
-    hash::{Hash, Hasher},
-    net::{Ipv6Addr, SocketAddr},
-};
+use ggrs::{Message, PlayerType};
 
 use crate::{webrtc_socket::MessageLoopFuture, WebRtcSocket};
 
 #[derive(Debug)]
 pub struct WebRtcNonBlockingSocket {
     socket: WebRtcSocket,
-    fake_socket_addrs: HashMap<String, SocketAddr>,
-    fake_socket_addrs_reverse: HashMap<SocketAddr, String>,
 }
 
 impl WebRtcNonBlockingSocket {
     #[must_use]
     pub fn new<T: Into<String>>(room_url: T) -> (Self, MessageLoopFuture) {
         let (socket, message_loop) = WebRtcSocket::new(room_url);
-        (
-            Self {
-                socket,
-                fake_socket_addrs: Default::default(),
-                fake_socket_addrs_reverse: Default::default(),
-            },
-            message_loop,
-        )
+        (Self { socket }, message_loop)
     }
 
-    pub async fn wait_for_peers(&mut self, peers: usize) {
-        let new_peers = self.socket.wait_for_peers(peers).await;
-
-        for id in new_peers {
-            let fake_addr = make_fake_socket_addr(&id);
-            self.fake_socket_addrs.insert(id.clone(), fake_addr);
-            self.fake_socket_addrs_reverse.insert(fake_addr, id);
-        }
+    pub async fn wait_for_peers(&mut self, peers: usize) -> Vec<String> {
+        self.socket.wait_for_peers(peers).await
     }
 
-    pub fn accept_new_connections(&mut self) {
-        let new_peers = self.socket.accept_new_connections();
-        for peer in new_peers {
-            self.handle_new_peer_id(peer);
-        }
+    pub fn accept_new_connections(&mut self) -> Vec<String> {
+        self.socket.accept_new_connections()
     }
 
-    pub fn connected_peers(&self) -> Vec<SocketAddr> {
-        self.socket
-            .connected_peers()
-            .iter()
-            .map(|id| *self.fake_socket_addrs.get(id).unwrap())
-            .collect()
+    #[must_use]
+    pub fn connected_peers(&self) -> Vec<String> {
+        self.socket.connected_peers()
     }
 
-    pub fn players(&self) -> Vec<PlayerType> {
+    #[must_use]
+    pub fn players(&self) -> Vec<PlayerType<String>> {
         // needs to be consistent order across all peers
         let mut ids = self.socket.connected_peers();
         ids.push(self.socket.id().to_owned());
@@ -63,53 +38,27 @@ impl WebRtcNonBlockingSocket {
                 if id == self.socket.id() {
                     PlayerType::Local
                 } else {
-                    let addr = *self.fake_socket_addrs.get(id).unwrap();
-                    PlayerType::Remote(addr)
+                    PlayerType::Remote(id.to_owned())
                 }
             })
             .collect()
     }
-
-    fn get_or_create_fake_addr(&mut self, id: &str) -> SocketAddr {
-        match self.fake_socket_addrs.get(id) {
-            Some(fake_addr) => *fake_addr,
-            None => self.handle_new_peer_id(id.to_string()),
-        }
-    }
-
-    fn handle_new_peer_id(&mut self, id: String) -> SocketAddr {
-        let fake_addr = make_fake_socket_addr(&id);
-        self.fake_socket_addrs.insert(id.clone(), fake_addr);
-        self.fake_socket_addrs_reverse.insert(fake_addr, id);
-        fake_addr
-    }
 }
 
-impl ggrs::NonBlockingSocket<SocketAddr> for WebRtcNonBlockingSocket {
-    fn send_to(&mut self, msg: &UdpMessage, addr: &SocketAddr) {
-        let id = self.fake_socket_addrs_reverse[addr].clone();
+impl ggrs::NonBlockingSocket<String> for WebRtcNonBlockingSocket {
+    fn send_to(&mut self, msg: &Message, addr: &String) {
         let buf = bincode::serialize(&msg).unwrap();
         let packet = buf.into_boxed_slice();
-        self.socket.send(packet, id);
+        self.socket.send(packet, addr);
     }
 
-    fn receive_all_messages(&mut self) -> Vec<(SocketAddr, UdpMessage)> {
+    fn receive_all_messages(&mut self) -> Vec<(String, Message)> {
         // let fake_socket_addrs = self.fake_socket_addrs.clone();
         let mut messages = vec![];
         for (id, packet) in self.socket.receive().into_iter() {
             let msg = bincode::deserialize(&packet).unwrap();
-            let addr = self.get_or_create_fake_addr(&id);
-            messages.push((addr, msg));
+            messages.push((id, msg));
         }
         messages
     }
-}
-
-fn make_fake_socket_addr(id: &str) -> SocketAddr {
-    // TODO: This is a horrible lazy hack, but let's just try to get it working
-    let mut hasher = DefaultHasher::new();
-    id.hash(&mut hasher);
-    let hash = hasher.finish();
-    let a: u16 = hash as u16;
-    SocketAddr::new(Ipv6Addr::new(a, a, a, a, a, a, a, a).into(), 1111)
 }


### PR DESCRIPTION
As the title says.

matchbox_socket:
- updated to match ggrs 0.9 API
- removed the String <-> SocketAddr hack. this is almost the same as in branch `string-ids-wip`

matchbox_demo:
- updated to match ggrs 0.9 API
- repositioned the camera of the box game
- minor tweaks for the cube movement

Tested; runs with local matchbox_server. I did not experience the freezing after ~1 minute that we discussed on discord.