### PR TITLE
demo: Fix issues with disconnections after upgrading to ggrs 0.9.1

### DIFF
--- a/matchbox_demo/Cargo.toml
+++ b/matchbox_demo/Cargo.toml
@@ -24,11 +24,12 @@ console_error_panic_hook = "0.1"
 console_log = "0.2"
 serde_qs = "0.9"
 wasm-bindgen = "0.2"
+ggrs = { version = "0.9.1", features = ["wasm-bindgen"] }
 
 [dependencies]
 matchbox_socket = { path = "../matchbox_socket", features = ["ggrs-socket"] }
 bevy = { version = "0.6", default-features = false }
-ggrs = "0.9"
+ggrs = "0.9.1"
 bevy_ggrs = "0.9"
 bytemuck = { version = "1.7", features=["derive"]}
 clap = { version = "3.0", features = ["derive"] }


### PR DESCRIPTION
ggrs now requires the wasm-bindgen feature to be enabled to work
properly on wasm