### PR TITLE
cross native and wasm, ice trickle and data channel creation

### DIFF
--- a/matchbox_socket/Cargo.toml
+++ b/matchbox_socket/Cargo.toml
@@ -39,7 +39,7 @@ web-sys = { version = "0.3.22", default-features = false, features = [
     "MessageEvent",
     "RtcPeerConnection",
     "RtcSdpType", "RtcSessionDescription", "RtcSessionDescriptionInit",
-    "RtcIceGatheringState", "RtcIceCandidate", "RtcIceCandidateInit", "RtcIceTransportPolicy",
+    "RtcIceGatheringState", "RtcIceCandidate", "RtcIceCandidateInit",
     "RtcConfiguration", "RtcDataChannel", "RtcDataChannelInit", "RtcDataChannelType",
 ] }
 serde-wasm-bindgen = { version = "0.4" }

--- a/matchbox_socket/Cargo.toml
+++ b/matchbox_socket/Cargo.toml
@@ -39,7 +39,7 @@ web-sys = { version = "0.3.22", default-features = false, features = [
     "MessageEvent",
     "RtcPeerConnection",
     "RtcSdpType", "RtcSessionDescription", "RtcSessionDescriptionInit",
-    "RtcIceGatheringState",
+    "RtcIceGatheringState", "RtcIceCandidate", "RtcIceCandidateInit", "RtcIceTransportPolicy",
     "RtcConfiguration", "RtcDataChannel", "RtcDataChannelInit", "RtcDataChannelType",
 ] }
 serde-wasm-bindgen = { version = "0.4" }

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -8,6 +8,7 @@ mod messages;
 mod signal_peer;
 
 const KEEP_ALIVE_INTERVAL: u64 = 10_000;
+const DATA_CHANNEL_ID: u16 = 124;
 
 // TODO: maybe use cfg-if to make this slightly tidier
 #[cfg(not(target_arch = "wasm32"))]

--- a/matchbox_socket/src/webrtc_socket/native/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/native/message_loop.rs
@@ -26,7 +26,7 @@ use webrtc::{
 use crate::webrtc_socket::{
     messages::{PeerEvent, PeerId, PeerRequest, PeerSignal},
     signal_peer::SignalPeer,
-    Packet, WebRtcSocketConfig, KEEP_ALIVE_INTERVAL,
+    Packet, WebRtcSocketConfig, DATA_CHANNEL_ID, KEEP_ALIVE_INTERVAL,
 };
 
 pub async fn message_loop(
@@ -426,7 +426,7 @@ async fn create_data_channel(
     let config = RTCDataChannelInit {
         ordered: Some(false),
         max_retransmits: Some(0),
-        negotiated: Some(124),
+        negotiated: Some(DATA_CHANNEL_ID),
         ..Default::default()
     };
 

--- a/matchbox_socket/src/webrtc_socket/native/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/native/message_loop.rs
@@ -317,6 +317,16 @@ async fn handshake_accept(
     debug!("handshake_accept");
     let (connection, trickle) = create_rtc_peer_connection(signal_peer.clone(), config).await?;
 
+    let (channel_ready_tx, mut channel_ready_rx) = futures_channel::mpsc::channel(1);
+    let data_channel = create_data_channel(
+        &connection,
+        channel_ready_tx,
+        signal_peer.id.clone(),
+        new_peer_tx,
+        from_peer_message_tx,
+    )
+    .await;
+
     let offer;
     loop {
         match signal_receiver.next().await.ok_or("error")? {
@@ -347,23 +357,15 @@ async fn handshake_accept(
             .fuse(),
     );
 
-    let data_channel_fut = wait_for_data_channel(
-        &connection,
-        signal_peer.id.clone(),
-        new_peer_tx,
-        from_peer_message_tx,
-    )
-    .fuse();
-    pin_mut!(data_channel_fut);
-
-    let data_channel = loop {
+    let mut channel_ready_fut = channel_ready_rx.next();
+    loop {
         select! {
-            data_channel = data_channel_fut => break data_channel,
+            _ = channel_ready_fut => break,
             // TODO: this means that the signalling is down, should return an
             // error
             _ = trickle_fut => continue,
         };
-    };
+    }
 
     Ok((signal_peer.id, data_channel, trickle_fut))
 }
@@ -424,6 +426,7 @@ async fn create_data_channel(
     let config = RTCDataChannelInit {
         ordered: Some(false),
         max_retransmits: Some(0),
+        negotiated: Some(124),
         ..Default::default()
     };
 
@@ -444,40 +447,6 @@ async fn create_data_channel(
     setup_data_channel(&channel, peer_id, from_peer_message_tx).await;
 
     channel
-}
-
-async fn wait_for_data_channel(
-    connection: &RTCPeerConnection,
-    peer_id: PeerId,
-    new_peer_tx: UnboundedSender<PeerId>,
-    from_peer_message_tx: UnboundedSender<(PeerId, Packet)>,
-) -> Arc<RTCDataChannel> {
-    let (channel_tx, mut channel_rx) = futures_channel::mpsc::channel(1);
-
-    connection.on_data_channel(Box::new(move |channel| {
-        debug!("new data channel");
-        let peer_id = peer_id.clone();
-        let mut new_peer_tx = new_peer_tx.clone();
-        let from_peer_message_tx = from_peer_message_tx.clone();
-        let mut channel_tx = channel_tx.clone();
-        Box::pin(async move {
-            let peer_id2 = peer_id.clone();
-            let channel2 = Arc::clone(&channel);
-
-            // TODO: register close & error callbacks
-            channel.on_open(Box::new(move || {
-                debug!("Data channel ready");
-                Box::pin(async move {
-                    new_peer_tx.send(peer_id2).await.unwrap();
-                    channel_tx.try_send(channel2).unwrap();
-                })
-            }));
-
-            setup_data_channel(&channel, peer_id, from_peer_message_tx).await;
-        })
-    }));
-
-    channel_rx.next().await.unwrap()
 }
 
 async fn setup_data_channel(

--- a/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
@@ -15,11 +15,10 @@ use web_sys::{
     RtcIceCandidate, RtcIceCandidateInit, RtcPeerConnection, RtcSdpType, RtcSessionDescriptionInit,
 };
 
-use crate::webrtc_socket::KEEP_ALIVE_INTERVAL;
 use crate::webrtc_socket::{
     messages::{PeerEvent, PeerId, PeerRequest, PeerSignal},
     signal_peer::SignalPeer,
-    Packet, WebRtcSocketConfig,
+    Packet, WebRtcSocketConfig, DATA_CHANNEL_ID, KEEP_ALIVE_INTERVAL,
 };
 
 pub async fn message_loop(
@@ -416,7 +415,7 @@ fn create_data_channel(
     data_channel_config.ordered(false);
     data_channel_config.max_retransmits(0);
     data_channel_config.negotiated(true);
-    data_channel_config.id(124);
+    data_channel_config.id(DATA_CHANNEL_ID);
 
     let channel: RtcDataChannel =
         connection.create_data_channel_with_data_channel_dict("webudp", &data_channel_config);

--- a/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
@@ -12,8 +12,7 @@ use wasm_bindgen::{prelude::*, JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{
     MessageEvent, RtcConfiguration, RtcDataChannel, RtcDataChannelInit, RtcDataChannelType,
-    RtcIceCandidate, RtcIceCandidateInit, RtcIceTransportPolicy, RtcPeerConnection, RtcSdpType,
-    RtcSessionDescriptionInit,
+    RtcIceCandidate, RtcIceCandidateInit, RtcPeerConnection, RtcSdpType, RtcSessionDescriptionInit,
 };
 
 use crate::webrtc_socket::KEEP_ALIVE_INTERVAL;


### PR DESCRIPTION
This is an attempt to get cross data communication between native and WASM WebRTC, to address https://github.com/johanhelsing/matchbox/issues/47

The screenshot shows our own app using matchbox, 2 chrome tabs, 1 firefox tab, 2 desktop (native), all communicating with each other. We also tested order of launching and making sure no matter who offers or accepts it still connects. But this is all pretty tricky and might still have some bugs. 

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/92162/207790352-58435e63-9d78-4a4e-b98b-aeff0407d066.png">
