### PR TITLE
Remove RtcIceCandidate hacks

### DIFF
--- a/matchbox_socket/Cargo.toml
+++ b/matchbox_socket/Cargo.toml
@@ -39,7 +39,7 @@ web-sys = { version = "0.3.22", default-features = false, features = [
     "MessageEvent",
     "RtcPeerConnection",
     "RtcSdpType", "RtcSessionDescription", "RtcSessionDescriptionInit",
-    "RtcIceGatheringState", "RtcIceCandidate", "RtcIceCandidateInit",
+    "RtcIceGatheringState", "RtcIceCandidate", "RtcIceCandidateInit", "RtcPeerConnectionIceEvent",
     "RtcConfiguration", "RtcDataChannel", "RtcDataChannelInit", "RtcDataChannelType",
 ] }
 serde-wasm-bindgen = { version = "0.4" }

--- a/matchbox_socket/src/webrtc_socket/native/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/native/message_loop.rs
@@ -17,8 +17,7 @@ use webrtc::{
         ice_server::RTCIceServer,
     },
     peer_connection::{
-        configuration::RTCConfiguration,
-        sdp::{sdp_type::RTCSdpType, session_description::RTCSessionDescription},
+        configuration::RTCConfiguration, sdp::session_description::RTCSessionDescription,
         RTCPeerConnection,
     },
 };
@@ -265,7 +264,7 @@ async fn handshake_offer(
     connection.set_local_description(offer).await?;
     signal_peer.send(PeerSignal::Offer(sdp));
 
-    let sdp = loop {
+    let answer = loop {
         let signal = signal_receiver
             .next()
             .await
@@ -284,9 +283,7 @@ async fn handshake_offer(
         };
     };
 
-    let mut remote_description = RTCSessionDescription::default();
-    remote_description.sdp = sdp;
-    remote_description.sdp_type = RTCSdpType::Answer; // TODO: Or leave unspecified?
+    let remote_description = RTCSessionDescription::answer(answer)?;
     connection
         .set_remote_description(remote_description)
         .await?;
@@ -347,9 +344,7 @@ async fn handshake_accept(
         }
     };
     debug!("received offer");
-    let mut remote_description = RTCSessionDescription::default();
-    remote_description.sdp = offer;
-    remote_description.sdp_type = RTCSdpType::Offer; // TODO: Or leave unspecified?
+    let remote_description = RTCSessionDescription::offer(offer)?;
     connection
         .set_remote_description(remote_description)
         .await?;

--- a/matchbox_socket/src/webrtc_socket/native/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/native/message_loop.rs
@@ -265,9 +265,7 @@ async fn handshake_offer(
     connection.set_local_description(offer).await?;
     signal_peer.send(PeerSignal::Offer(sdp));
 
-    let sdp: String;
-
-    loop {
+    let sdp = loop {
         let signal = signal_receiver
             .next()
             .await
@@ -275,8 +273,7 @@ async fn handshake_offer(
 
         match signal {
             PeerSignal::Answer(answer) => {
-                sdp = answer;
-                break;
+                break answer;
             }
             PeerSignal::Offer(_) => {
                 warn!("Got an unexpected Offer, while waiting for Answer. Ignoring.")
@@ -285,7 +282,7 @@ async fn handshake_offer(
                 warn!("Got an unexpected IceCandidate, while waiting for Answer. Ignoring.")
             }
         };
-    }
+    };
 
     let mut remote_description = RTCSessionDescription::default();
     remote_description.sdp = sdp;
@@ -339,18 +336,16 @@ async fn handshake_accept(
     )
     .await;
 
-    let offer;
-    loop {
+    let offer = loop {
         match signal_receiver.next().await.ok_or("error")? {
-            PeerSignal::Offer(o) => {
-                offer = o;
-                break;
+            PeerSignal::Offer(offer) => {
+                break offer;
             }
             _ => {
                 warn!("ignoring other signal!!!");
             }
         }
-    }
+    };
     debug!("received offer");
     let mut remote_description = RTCSessionDescription::default();
     remote_description.sdp = offer;

--- a/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
@@ -213,8 +213,7 @@ async fn handshake_offer(
 
     // handle pending ICE candidates
     for candidate in received_candidates {
-        let mut ice_candidate = RtcIceCandidateInit::new(&candidate);
-        ice_candidate.sdp_m_line_index(Some(0));
+        let ice_candidate = RtcIceCandidateInit::new(&candidate);
         JsFuture::from(
             conn.add_ice_candidate_with_opt_rtc_ice_candidate_init(Some(&ice_candidate)),
         )
@@ -233,8 +232,7 @@ async fn handshake_offer(
             msg = signal_receiver.next() => {
                 if let Some(PeerSignal::IceCandidate(candidate)) = msg {
                     debug!("got an IceCandidate signal! {}", candidate);
-                    let mut ice_candidate = RtcIceCandidateInit::new(&candidate);
-                    ice_candidate.sdp_m_line_index(Some(0));
+                    let ice_candidate = RtcIceCandidateInit::new(&candidate);
                     JsFuture::from(
                         conn.add_ice_candidate_with_opt_rtc_ice_candidate_init(Some(&ice_candidate)),
                     )
@@ -348,8 +346,7 @@ async fn handshake_accept(
 
     // handle pending ICE candidates
     for candidate in received_candidates {
-        let mut ice_candidate = RtcIceCandidateInit::new(&candidate);
-        ice_candidate.sdp_m_line_index(Some(0));
+        let ice_candidate = RtcIceCandidateInit::new(&candidate);
         JsFuture::from(
             conn.add_ice_candidate_with_opt_rtc_ice_candidate_init(Some(&ice_candidate)),
         )
@@ -368,8 +365,7 @@ async fn handshake_accept(
             msg = signal_receiver.next() => {
                 if let Some(PeerSignal::IceCandidate(candidate)) = msg {
                     debug!("got an IceCandidate signal! {}", candidate);
-                    let mut ice_candidate = RtcIceCandidateInit::new(&candidate);
-                    ice_candidate.sdp_m_line_index(Some(0));
+                    let ice_candidate = RtcIceCandidateInit::new(&candidate);
                     JsFuture::from(
                         conn.add_ice_candidate_with_opt_rtc_ice_candidate_init(Some(&ice_candidate)),
                     )


### PR DESCRIPTION
We had some hacks in place due to broken candidate serialization in webrtc-rs 0.4.