### PR TITLE
Allow to configure the RtcDataChannel

### DIFF
--- a/matchbox_socket/src/lib.rs
+++ b/matchbox_socket/src/lib.rs
@@ -5,4 +5,4 @@
 mod ggrs_socket;
 mod webrtc_socket;
 
-pub use webrtc_socket::{RtcIceServerConfig, WebRtcSocket, WebRtcSocketConfig};
+pub use webrtc_socket::{RtcDataChannelConfig, RtcIceServerConfig, WebRtcSocket, WebRtcSocketConfig};

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -63,8 +63,8 @@ pub struct WebRtcSocketConfig {
 /// See also: <https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel>
 #[derive(Debug)]
 pub struct RtcDataChannelConfig {
-    ordered: bool,
-    max_retransmits: u16,
+    pub ordered: bool,
+    pub max_retransmits: u16,
 }
 
 /// Configuration options for an ICE server connection.

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -63,7 +63,9 @@ pub struct WebRtcSocketConfig {
 /// See also: <https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel>
 #[derive(Debug)]
 pub struct RtcDataChannelConfig {
+    /// whether in-order delivery is guaranteed
     pub ordered: bool,
+    /// The maximum number of times the browser will try to retransmit a message before giving up
     pub max_retransmits: u16,
 }
 

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -55,6 +55,16 @@ pub struct WebRtcSocketConfig {
     pub room_url: String,
     /// Configuration for the (single) ICE server
     pub ice_server: RtcIceServerConfig,
+    /// Configuration for the (single) data channel
+    pub data_channel: RtcDataChannelConfig,
+}
+
+/// Configuration options for an RTC data channel.
+/// See also: <https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel>
+#[derive(Debug)]
+pub struct RtcDataChannelConfig {
+    ordered: bool,
+    max_retransmits: u16,
 }
 
 /// Configuration options for an ICE server connection.
@@ -71,6 +81,15 @@ pub struct RtcIceServerConfig {
     ///
     /// See: <https://developer.mozilla.org/en-US/docs/Web/API/RTCIceServer/credential>
     pub credential: Option<String>,
+}
+
+impl Default for RtcDataChannelConfig {
+    fn default() -> Self {
+        Self { 
+            ordered: false, 
+            max_retransmits: 0 
+        }
+    }
 }
 
 impl Default for RtcIceServerConfig {
@@ -92,6 +111,7 @@ impl Default for WebRtcSocketConfig {
         WebRtcSocketConfig {
             room_url: "ws://localhost:3536/example_room".to_string(),
             ice_server: RtcIceServerConfig::default(),
+            data_channel: RtcDataChannelConfig::default(),
         }
     }
 }

--- a/matchbox_socket/src/webrtc_socket/native/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/native/message_loop.rs
@@ -23,6 +23,7 @@ use webrtc::{
     },
 };
 
+use crate::webrtc_socket::RtcDataChannelConfig;
 use crate::webrtc_socket::{
     messages::{PeerEvent, PeerId, PeerRequest, PeerSignal},
     signal_peer::SignalPeer,
@@ -244,6 +245,7 @@ async fn handshake_offer(
         signal_peer.id.clone(),
         new_peer_tx,
         from_peer_message_tx,
+        &config.data_channel,
     )
     .await;
 
@@ -420,10 +422,11 @@ async fn create_data_channel(
     peer_id: PeerId,
     mut new_peer_tx: UnboundedSender<PeerId>,
     from_peer_message_tx: UnboundedSender<(PeerId, Packet)>,
+    config: &RtcDataChannelConfig,
 ) -> Arc<RTCDataChannel> {
     let config = RTCDataChannelInit {
-        ordered: Some(false),
-        max_retransmits: Some(0),
+        ordered: Some(config.ordered),
+        max_retransmits: Some(config.max_retransmits),
         ..Default::default()
     };
 

--- a/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
@@ -19,7 +19,7 @@ use crate::webrtc_socket::KEEP_ALIVE_INTERVAL;
 use crate::webrtc_socket::{
     messages::{PeerEvent, PeerId, PeerRequest, PeerSignal},
     signal_peer::SignalPeer,
-    Packet, WebRtcSocketConfig,
+    Packet, WebRtcSocketConfig, RtcDataChannelConfig
 };
 
 pub async fn message_loop(
@@ -138,6 +138,7 @@ async fn handshake_offer(
         messages_from_peers_tx,
         signal_peer.id.clone(),
         channel_ready_tx,
+        &config.data_channel,
     );
 
     let offer = JsFuture::from(conn.create_offer()).await.efix()?;
@@ -217,6 +218,7 @@ async fn handshake_accept(
         messages_from_peers_tx,
         signal_peer.id.clone(),
         channel_ready_tx,
+        &config.data_channel,
     );
 
     let offer: Option<String>;
@@ -327,7 +329,7 @@ fn create_data_channel(
     incoming_tx: futures_channel::mpsc::UnboundedSender<(PeerId, Packet)>,
     peer_id: PeerId,
     mut channel_ready: futures_channel::mpsc::Sender<u8>,
-    config: &DataChannelConfig,
+    config: &RtcDataChannelConfig,
 ) -> RtcDataChannel {
     let mut data_channel_config: RtcDataChannelInit = RtcDataChannelInit::new();
     data_channel_config.ordered(config.ordered);

--- a/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
@@ -327,10 +327,11 @@ fn create_data_channel(
     incoming_tx: futures_channel::mpsc::UnboundedSender<(PeerId, Packet)>,
     peer_id: PeerId,
     mut channel_ready: futures_channel::mpsc::Sender<u8>,
+    config: &DataChannelConfig,
 ) -> RtcDataChannel {
     let mut data_channel_config: RtcDataChannelInit = RtcDataChannelInit::new();
-    data_channel_config.ordered(false);
-    data_channel_config.max_retransmits(0);
+    data_channel_config.ordered(config.ordered);
+    data_channel_config.max_retransmits(config.max_retransmits);
     data_channel_config.negotiated(true);
     data_channel_config.id(0);
 


### PR DESCRIPTION
Matchbox was created to support unreliable data channels. However I need reliable channels for my project and it seems very easy to support it - so why not add a configuration option :)

It works really well for my wasm-based game in the browser and I also quickly tried locally if it breaks matchbox_demo (which it doesn't) - so please feel free to merge the PR if you deem it helpful!