### PR TITLE
Support multiple reliable and unreliable data channels

### DIFF
--- a/matchbox_socket/src/lib.rs
+++ b/matchbox_socket/src/lib.rs
@@ -5,4 +5,4 @@
 mod ggrs_socket;
 mod webrtc_socket;
 
-pub use webrtc_socket::{RtcIceServerConfig, WebRtcSocket, WebRtcSocketConfig};
+pub use webrtc_socket::{EnhancedPacket, RtcIceServerConfig, WebRtcSocket, WebRtcSocketConfig};

--- a/matchbox_socket/src/lib.rs
+++ b/matchbox_socket/src/lib.rs
@@ -5,4 +5,4 @@
 mod ggrs_socket;
 mod webrtc_socket;
 
-pub use webrtc_socket::{EnhancedPacket, RtcIceServerConfig, WebRtcSocket, WebRtcSocketConfig};
+pub use webrtc_socket::{ChannelConfig, RtcIceServerConfig, WebRtcSocket, WebRtcSocketConfig};

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -259,13 +259,14 @@ impl WebRtcSocket {
     }
 
     /// Send a packet to the given peer without any guarantees to arrive in order or at all
+    /// For more control over how the packet is sent use [`WebRtcSocket::send_enhanced`]
     pub fn send<T: Into<PeerId>>(&mut self, packet: Packet, id: T) {
         self.peer_messages_out
             .unbounded_send((id.into(), Channel::Reliable.get_channel_index(), packet))
             .expect("send_to failed");
     }
 
-    /// Send a packet with given options
+    /// Send a packet with given options via [`EnhancedPacket`]
     pub fn send_enhanced(&mut self, packet: EnhancedPacket) {
         self.peer_messages_out
             .unbounded_send((

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -167,6 +167,10 @@ impl WebRtcSocket {
     /// The returned future should be awaited in order for messages to be sent and received.
     #[must_use]
     pub fn new_with_config(config: WebRtcSocketConfig) -> (Self, MessageLoopFuture) {
+        if config.channels.is_empty() {
+            panic!("You need to configure at least one channel in WebRtcSocketConfig");
+        }
+
         let (messages_from_peers_tx, messages_from_peers) = new_senders_and_receivers(&config);
         let (new_connected_peers_tx, new_connected_peers) = futures_channel::mpsc::unbounded();
         let (peer_messages_out_tx, peer_messages_out_rx) = new_senders_and_receivers(&config);

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -37,7 +37,7 @@ use uuid::Uuid;
 
 type Packet = Box<[u8]>;
 
-/// General configuration options for a WebRtc connection
+/// General configuration options for a WebRtc connection.
 ///
 /// See [`WebRtcSocket::new_with_config`]
 #[derive(Debug)]
@@ -149,7 +149,7 @@ pub(crate) type MessageLoopFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 pub(crate) type MessageLoopFuture = Pin<Box<dyn Future<Output = ()>>>;
 
 impl WebRtcSocket {
-    /// Create a new connection to the given room
+    /// Create a new connection to the given room with a single unreliable data channel
     ///
     /// See [`WebRtcSocketConfig::room_url`] for details on the room url.
     ///
@@ -215,7 +215,6 @@ impl WebRtcSocket {
         let mut ids = Vec::new();
         while let Ok(Some(id)) = self.new_connected_peers.try_next() {
             if !self.peers.contains(&id) {
-                // Maybe we should make peers a HashSet instead?
                 self.peers.push(id.clone());
                 ids.push(id);
             }

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -335,7 +335,7 @@ pub(crate) fn new_senders_and_receivers<T>(
         .unzip()
 }
 
-fn channel_readiness(
+fn create_data_channels_ready_fut(
     config: &WebRtcSocketConfig,
 ) -> (
     Vec<futures_channel::mpsc::Sender<u8>>,

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -1,6 +1,7 @@
 use std::pin::Pin;
 
 use futures::{Future, FutureExt, StreamExt};
+use futures_channel::mpsc::{UnboundedReceiver, UnboundedSender};
 use futures_util::select;
 use log::debug;
 
@@ -8,8 +9,6 @@ mod messages;
 mod signal_peer;
 
 const KEEP_ALIVE_INTERVAL: u64 = 10_000;
-const RELIABLE_DATA_CHANNEL_ID: u16 = 125;
-const UNRELIABLE_DATA_CHANNEL_ID: u16 = 124;
 
 // TODO: maybe use cfg-if to make this slightly tidier
 #[cfg(not(target_arch = "wasm32"))]
@@ -37,7 +36,6 @@ use messages::*;
 use uuid::Uuid;
 
 type Packet = Box<[u8]>;
-type ChannelIndex = usize;
 
 /// General configuration options for a WebRtc connection
 ///
@@ -58,6 +56,8 @@ pub struct WebRtcSocketConfig {
     pub room_url: String,
     /// Configuration for the (single) ICE server
     pub ice_server: RtcIceServerConfig,
+    /// Configuration for one or multiple reliable or unreliable data channels
+    pub channels: Vec<ChannelConfig>,
 }
 
 /// Configuration options for an ICE server connection.
@@ -76,6 +76,46 @@ pub struct RtcIceServerConfig {
     pub credential: Option<String>,
 }
 
+/// Configuration options for a data channel
+/// See also: https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel
+#[derive(Debug)]
+pub struct ChannelConfig {
+    /// Whether messages sent on the channel are guaranteed to arrive in order
+    /// See also: https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/ordered
+    pub ordered: bool,
+    /// Maximum number of retransmit attempts of a message before giving up
+    /// See also: https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/maxRetransmits
+    pub max_retransmits: Option<u16>,
+}
+
+impl ChannelConfig {
+    /// Messages sent via an unreliable channel may arrive in any order or not at all, but arrive as quickly as possible
+    pub fn unreliable() -> Self {
+        ChannelConfig {
+            ordered: false,
+            max_retransmits: Some(0),
+        }
+    }
+
+    /// Messages sent via a reliable channel are guaranteed to arrive in order and will be resent until they arrive
+    pub fn reliable() -> Self {
+        ChannelConfig {
+            ordered: true,
+            max_retransmits: None,
+        }
+    }
+}
+
+impl Default for WebRtcSocketConfig {
+    fn default() -> Self {
+        WebRtcSocketConfig {
+            room_url: "ws://localhost:3536/example_room".to_string(),
+            ice_server: RtcIceServerConfig::default(),
+            channels: vec![ChannelConfig::unreliable()],
+        }
+    }
+}
+
 impl Default for RtcIceServerConfig {
     fn default() -> Self {
         Self {
@@ -90,58 +130,14 @@ impl Default for RtcIceServerConfig {
     }
 }
 
-impl Default for WebRtcSocketConfig {
-    fn default() -> Self {
-        WebRtcSocketConfig {
-            room_url: "ws://localhost:3536/example_room".to_string(),
-            ice_server: RtcIceServerConfig::default(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub(crate) enum Channel {
-    Reliable,
-    Unreliable,
-}
-
-impl Channel {
-    pub fn get_channel_index(&self) -> ChannelIndex {
-        match self {
-            Channel::Reliable => 1,
-            Channel::Unreliable => 0,
-        }
-    }
-}
-
-/// Allows to get or set details about how a packet was or should be sent
-pub struct EnhancedPacket {
-    /// The actual data to be sent
-    pub packet: Packet,
-    /// The peer to send the data to
-    pub peer_id: PeerId,
-    /// Packets sent via a reliable channel are guaranteed to arrive and to arrive in order
-    pub via_reliable_channel: bool,
-}
-
-impl EnhancedPacket {
-    fn channel_index(&self) -> ChannelIndex {
-        if self.via_reliable_channel {
-            Channel::Reliable.get_channel_index()
-        } else {
-            Channel::Unreliable.get_channel_index()
-        }
-    }
-}
-
 /// Contains the interface end of a full-mesh web rtc connection
 ///
 /// Used to send and receive messages from other peers
 #[derive(Debug)]
 pub struct WebRtcSocket {
-    messages_from_peers: futures_channel::mpsc::UnboundedReceiver<(PeerId, ChannelIndex, Packet)>,
+    messages_from_peers: Vec<futures_channel::mpsc::UnboundedReceiver<(PeerId, Packet)>>,
     new_connected_peers: futures_channel::mpsc::UnboundedReceiver<PeerId>,
-    peer_messages_out: futures_channel::mpsc::UnboundedSender<(PeerId, ChannelIndex, Packet)>,
+    peer_messages_out: Vec<futures_channel::mpsc::UnboundedSender<(PeerId, Packet)>>,
     peers: Vec<PeerId>,
     id: PeerId,
 }
@@ -171,10 +167,9 @@ impl WebRtcSocket {
     /// The returned future should be awaited in order for messages to be sent and received.
     #[must_use]
     pub fn new_with_config(config: WebRtcSocketConfig) -> (Self, MessageLoopFuture) {
-        let (messages_from_peers_tx, messages_from_peers) = futures_channel::mpsc::unbounded();
+        let (messages_from_peers_tx, messages_from_peers) = new_senders_and_receivers(&config);
         let (new_connected_peers_tx, new_connected_peers) = futures_channel::mpsc::unbounded();
-        let (peer_messages_out_tx, peer_messages_out_rx) =
-            futures_channel::mpsc::unbounded::<(PeerId, ChannelIndex, Packet)>();
+        let (peer_messages_out_tx, peer_messages_out_rx) = new_senders_and_receivers(&config);
 
         // Would perhaps be smarter to let signalling server decide this...
         let id = Uuid::new_v4().to_string();
@@ -202,6 +197,9 @@ impl WebRtcSocket {
         debug!("waiting for peers to join");
         let mut addrs = vec![];
         while let Some(id) = self.new_connected_peers.next().await {
+            if addrs.contains(&id) {
+                continue;
+            }
             addrs.push(id.clone());
             if addrs.len() == peers {
                 debug!("all peers joined");
@@ -219,8 +217,8 @@ impl WebRtcSocket {
             if !self.peers.contains(&id) {
                 // Maybe we should make peers a HashSet instead?
                 self.peers.push(id.clone());
+                ids.push(id);
             }
-            ids.push(id);
         }
         ids
     }
@@ -230,50 +228,52 @@ impl WebRtcSocket {
         self.peers.clone() // TODO: could probably be an iterator or reference instead?
     }
 
-    /// Call this where you want to handle new received messages
+    /// Call this where you want to handle new received messages from the default channel (with index 0) which will be the only
+    /// channel if you didn't configure any explicitly
     ///
     /// messages are removed from the socket when called
+    /// See also: [`WebRtcSocket::receive_on_channel`]
     pub fn receive(&mut self) -> Vec<(PeerId, Packet)> {
-        self.receive_enhanced()
-            .into_iter()
-            .map(|p| (p.peer_id.clone(), p.packet))
-            .collect()
+        self.receive_on_channel(0)
     }
 
-    /// Call this where you want to handle new received messages together with more details about them
+    /// Call this where you want to handle new received messages from a specific channel as configured in [`WebRtcSocketConfig::channels`].
+    /// The index of a channel is its index in the vec [`WebRtcSocketConfig::channels`] as you configured it before
+    /// (or 0 for the default channel if you use the default configuration).
     ///
-    /// messages are removed from the socket when called
-    pub fn receive_enhanced(&mut self) -> Vec<EnhancedPacket> {
-        std::iter::repeat_with(|| self.messages_from_peers.try_next())
-            // .map_while(|poll| match p { // map_while is nightly-only :(
-            .take_while(|p| !p.is_err())
-            .map(|p| match p.unwrap() {
-                Some((peer_id, channel_index, packet)) => EnhancedPacket {
-                    packet,
-                    peer_id,
-                    via_reliable_channel: channel_index == Channel::Reliable.get_channel_index(),
-                },
-                None => todo!("Handle connection closed??"),
-            })
-            .collect()
+    /// messages are removed from the socket when called   
+    pub fn receive_on_channel(&mut self, index: usize) -> Vec<(PeerId, Packet)> {
+        std::iter::repeat_with(|| {
+            self.messages_from_peers
+                .get_mut(index)
+                .unwrap_or_else(|| panic!("No data channel with index {}", index))
+                .try_next()
+        })
+        // .map_while(|poll| match p { // map_while is nightly-only :(
+        .take_while(|p| !p.is_err())
+        .map(|p| match p.unwrap() {
+            Some((peer_id, packet)) => (peer_id, packet),
+            None => todo!("Handle connection closed??"),
+        })
+        .collect()
     }
 
-    /// Send a packet to the given peer without any guarantees to arrive in order or at all
-    /// For more control over how the packet is sent use [`WebRtcSocket::send_enhanced`]
+    /// Send a packet to the given peer on the default channel (with index 0) which will be the only
+    /// channel if you didn't configure any explicitly
+    ///
+    /// See also [`WebRtcSocket::send_on_channel`]
     pub fn send<T: Into<PeerId>>(&mut self, packet: Packet, id: T) {
-        self.peer_messages_out
-            .unbounded_send((id.into(), Channel::Reliable.get_channel_index(), packet))
-            .expect("send_to failed");
+        self.send_on_channel(packet, id, 0);
     }
 
-    /// Send a packet with given options via [`EnhancedPacket`]
-    pub fn send_enhanced(&mut self, packet: EnhancedPacket) {
+    /// Send a packet to the given peer on a specific channel as configured in [`WebRtcSocketConfig::channels`].
+    /// The index of a channel is its index in the vec [`WebRtcSocketConfig::channels`] as you configured it before
+    /// (or 0 for the default channel if you use the default configuration).
+    pub fn send_on_channel<T: Into<PeerId>>(&mut self, packet: Packet, id: T, index: usize) {
         self.peer_messages_out
-            .unbounded_send((
-                packet.peer_id.clone(),
-                packet.channel_index(),
-                packet.packet,
-            ))
+            .get(index)
+            .unwrap_or_else(|| panic!("No data channel with index {}", index))
+            .unbounded_send((id.into(), packet))
             .expect("send_to failed");
     }
 
@@ -286,9 +286,9 @@ impl WebRtcSocket {
 async fn run_socket(
     config: WebRtcSocketConfig,
     id: PeerId,
-    peer_messages_out_rx: futures_channel::mpsc::UnboundedReceiver<(PeerId, ChannelIndex, Packet)>,
+    peer_messages_out_rx: Vec<futures_channel::mpsc::UnboundedReceiver<(PeerId, Packet)>>,
     new_connected_peers_tx: futures_channel::mpsc::UnboundedSender<PeerId>,
-    messages_from_peers_tx: futures_channel::mpsc::UnboundedSender<(PeerId, ChannelIndex, Packet)>,
+    messages_from_peers_tx: Vec<futures_channel::mpsc::UnboundedSender<(PeerId, Packet)>>,
 ) {
     debug!("Starting WebRtcSocket message loop");
 
@@ -325,4 +325,12 @@ async fn run_socket(
             complete => break
         }
     }
+}
+
+pub(crate) fn new_senders_and_receivers<T>(
+    config: &WebRtcSocketConfig,
+) -> (Vec<UnboundedSender<T>>, Vec<UnboundedReceiver<T>>) {
+    (0..config.channels.len())
+        .map(|_| futures_channel::mpsc::unbounded())
+        .unzip()
 }

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -266,6 +266,7 @@ impl WebRtcSocket {
     }
 
     /// Send a packet to the given peer on a specific channel as configured in [`WebRtcSocketConfig::channels`].
+    ///
     /// The index of a channel is its index in the vec [`WebRtcSocketConfig::channels`] as you configured it before
     /// (or 0 for the default channel if you use the default configuration).
     pub fn send_on_channel<T: Into<PeerId>>(&mut self, packet: Packet, id: T, index: usize) {

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -230,6 +230,7 @@ impl WebRtcSocket {
     /// channel if you didn't configure any explicitly
     ///
     /// messages are removed from the socket when called
+    ///
     /// See also: [`WebRtcSocket::receive_on_channel`]
     pub fn receive(&mut self) -> Vec<(PeerId, Packet)> {
         self.receive_on_channel(0)

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -81,7 +81,7 @@ pub struct RtcIceServerConfig {
 #[derive(Debug)]
 pub struct ChannelConfig {
     /// Whether messages sent on the channel are guaranteed to arrive in order
-    /// See also: https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/ordered
+    /// See also: <https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/ordered>
     pub ordered: bool,
     /// Maximum number of retransmit attempts of a message before giving up
     /// See also: <https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/maxRetransmits>

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -84,7 +84,7 @@ pub struct ChannelConfig {
     /// See also: https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/ordered
     pub ordered: bool,
     /// Maximum number of retransmit attempts of a message before giving up
-    /// See also: https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/maxRetransmits
+    /// See also: <https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/maxRetransmits>
     pub max_retransmits: Option<u16>,
 }
 

--- a/matchbox_socket/src/webrtc_socket/native/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/native/message_loop.rs
@@ -143,7 +143,7 @@ async fn message_loop_impl(
                     Some((peer, channel_index, packet)) => {
                         let senders = connected_peers.get_mut(&peer)
                             .unwrap_or_else(|| panic!("couldn't find data channel for peer {}", peer));
-                        let sender = senders.get_mut(channel_index as usize)
+                        let sender = senders.get_mut(channel_index)
                             .unwrap_or_else(|| panic!("Unexpected data channel index during send: {}", channel_index));
                         sender.unbounded_send(packet).unwrap();
                     },

--- a/matchbox_socket/src/webrtc_socket/native/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/native/message_loop.rs
@@ -461,18 +461,18 @@ async fn create_data_channel(
     mut channel_ready: futures_channel::mpsc::Sender<u8>,
     peer_id: PeerId,
     from_peer_message_tx: UnboundedSender<(PeerId, Packet)>,
-    channel_type: &ChannelConfig,
+    channel_config: &ChannelConfig,
     channel_index: usize,
 ) -> Arc<RTCDataChannel> {
     let config = RTCDataChannelInit {
-        ordered: Some(channel_type.ordered),
+        ordered: Some(channel_config.ordered),
         negotiated: Some(channel_index as u16),
-        max_retransmits: channel_type.max_retransmits,
+        max_retransmits: channel_config.max_retransmits,
         ..Default::default()
     };
 
     let channel = connection
-        .create_data_channel("webudp", Some(config))
+        .create_data_channel(&format!("matchbox_socket_{channel_index}"), Some(config))
         .await
         .unwrap();
 

--- a/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
@@ -120,7 +120,7 @@ pub async fn message_loop(
                         let data_channel = data_channels.get(&peer)
                             .expect("couldn't find data channel for peer")
                             .get(channel_index)
-                            .expect(format!("couldn't find data channel with index {}", channel_index).as_str());
+                            .unwrap_or_else(|| panic!("couldn't find data channel with index {}", channel_index));
 
                         if let Err(err) = data_channel.send_with_u8_array(&packet) {
                             // This likely means the other peer disconnected
@@ -543,7 +543,7 @@ fn create_data_channel_pair(
             connection,
             incoming_tx,
             peer_id,
-            channel_ready.clone(),
+            channel_ready,
             Channel::Reliable,
         ),
     ]

--- a/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
@@ -429,7 +429,6 @@ async fn handshake_accept(
         try_add_rtc_ice_candidate(&conn, &candidate).await;
     }
 
-    // Do we need this or is it enough to wait until first channel opened?
     let mut channels_pending = data_channels.len();
 
     // select for channel ready or ice candidates
@@ -565,8 +564,10 @@ fn create_data_channel(
     let mut data_channel_config = data_channel_config(channel_type);
     data_channel_config.id(channel_id as u16);
 
-    let channel =
-        connection.create_data_channel_with_data_channel_dict("webudp", &data_channel_config);
+    let channel = connection.create_data_channel_with_data_channel_dict(
+        &format!("matchbox_socket_{channel_id}"),
+        &data_channel_config,
+    );
 
     channel.set_binary_type(RtcDataChannelType::Arraybuffer);
 

--- a/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
@@ -556,11 +556,7 @@ fn create_data_channel(
     mut channel_open: futures_channel::mpsc::Sender<u8>,
     channel_type: Channel,
 ) -> RtcDataChannel {
-    let mut data_channel_config = RtcDataChannelInit::new();
-    data_channel_config.ordered(false);
-    data_channel_config.max_retransmits(0);
-    data_channel_config.negotiated(true);
-    data_channel_config.id(DATA_CHANNEL_ID);
+    let mut data_channel_config = data_channel_config(channel_type);
 
     let channel =
         connection.create_data_channel_with_data_channel_dict("webudp", &data_channel_config);
@@ -571,7 +567,7 @@ fn create_data_channel(
         |f| channel.set_onopen(f),
         move |_: JsValue| {
             debug!("Rtc data channel opened :D :D");
-            channel_ready
+            channel_open
                 .try_send(1)
                 .expect("failed to notify about open connection");
         },

--- a/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
@@ -161,7 +161,7 @@ async fn handshake_offer(
     let conn = create_rtc_peer_connection(config);
     let (channel_open_tx, mut channel_open_rx) = futures_channel::mpsc::channel(1);
 
-    let data_channels = create_data_channel_pair(
+    let data_channels = create_data_channels(
         conn.clone(),
         messages_from_peers_tx,
         signal_peer.id.clone(),
@@ -328,7 +328,7 @@ async fn handshake_accept(
 
     let conn = create_rtc_peer_connection(config);
     let (channel_ready_tx, mut channel_ready_rx) = futures_channel::mpsc::channel(1);
-    let data_channels = create_data_channel_pair(
+    let data_channels = create_data_channels(
         conn.clone(),
         messages_from_peers_tx,
         signal_peer.id.clone(),
@@ -530,7 +530,7 @@ async fn wait_for_ice_gathering_complete(conn: RtcPeerConnection) {
     debug!("Ice gathering completed");
 }
 
-fn create_data_channel_pair(
+fn create_data_channels(
     connection: RtcPeerConnection,
     mut incoming_tx: Vec<futures_channel::mpsc::UnboundedSender<(PeerId, Packet)>>,
     peer_id: PeerId,

--- a/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
@@ -47,12 +47,11 @@ pub async fn message_loop(
     let mut timeout = Delay::new(Duration::from_millis(KEEP_ALIVE_INTERVAL)).fuse();
 
     loop {
-        let mut next_peer_messages_out = FuturesUnordered::new();
-        peer_messages_out_rx
+        let mut next_peer_messages_out: FuturesUnordered<_> = peer_messages_out_rx
             .iter_mut()
             .enumerate()
-            .map(|(index, r)| async move { (index, r.next().fuse().await) })
-            .for_each(|f| next_peer_messages_out.push(f));
+            .map(|(index, r)| async move { (index, r.next().await) })
+            .collect();
 
         let mut next_peer_message_out = next_peer_messages_out.next().fuse();
 

--- a/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
@@ -17,7 +17,7 @@ use web_sys::{
     RtcSdpType, RtcSessionDescriptionInit,
 };
 
-use crate::webrtc_socket::{channel_readiness, ChannelConfig};
+use crate::webrtc_socket::{create_data_channels_ready_fut, ChannelConfig};
 use crate::webrtc_socket::{
     messages::{PeerEvent, PeerId, PeerRequest, PeerSignal},
     signal_peer::SignalPeer,
@@ -159,7 +159,7 @@ async fn handshake_offer(
     debug!("making offer");
 
     let conn = create_rtc_peer_connection(config);
-    let (channel_ready_tx, mut wait_for_channels) = channel_readiness(config);
+    let (channel_ready_tx, mut wait_for_channels) = create_data_channels_ready_fut(config);
 
     let data_channels = create_data_channels(
         conn.clone(),
@@ -320,7 +320,7 @@ async fn handshake_accept(
     debug!("handshake_accept");
 
     let conn = create_rtc_peer_connection(config);
-    let (channel_ready_tx, mut wait_for_channels) = channel_readiness(config);
+    let (channel_ready_tx, mut wait_for_channels) = create_data_channels_ready_fut(config);
     let data_channels = create_data_channels(
         conn.clone(),
         messages_from_peers_tx,

--- a/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
@@ -546,10 +546,10 @@ fn create_data_channel(
     incoming_tx: futures_channel::mpsc::UnboundedSender<(PeerId, Packet)>,
     peer_id: PeerId,
     mut channel_open: futures_channel::mpsc::Sender<u8>,
-    channel_type: &ChannelConfig,
+    channel_config: &ChannelConfig,
     channel_id: usize,
 ) -> RtcDataChannel {
-    let mut data_channel_config = data_channel_config(channel_type);
+    let mut data_channel_config = data_channel_config(channel_config);
     data_channel_config.id(channel_id as u16);
 
     let channel = connection.create_data_channel_with_data_channel_dict(
@@ -615,13 +615,13 @@ fn leaking_channel_event_handler<T: FromWasmAbi + 'static>(
     closure.forget();
 }
 
-fn data_channel_config(channel_type: &ChannelConfig) -> RtcDataChannelInit {
+fn data_channel_config(channel_config: &ChannelConfig) -> RtcDataChannelInit {
     let mut data_channel_config = RtcDataChannelInit::new();
 
-    data_channel_config.ordered(channel_type.ordered);
+    data_channel_config.ordered(channel_config.ordered);
     data_channel_config.negotiated(true);
 
-    if let Some(n) = channel_type.max_retransmits {
+    if let Some(n) = channel_config.max_retransmits {
         data_channel_config.max_retransmits(n);
     }
 


### PR DESCRIPTION
Exploring your suggestions in #63 regarding #25 I tried an alternative implementation.

The two main differences beside some fixes are:
1) It is possible to receive a packet and at the same time understand from which channel it came
2) I use vectors instead of tuples to prepare for a later extension of the feature for more than two data channels

I decided to open two PRs for both variants because I am not sure which one is better. I like the simplicity of #63 and I tried to keep it in this PR - it is still possible to simply use the send() and receive() methods to not have to worry about the big world of WebRTC at all and remain blissfully oblivious of the data channels used backstage.

If the library user would like to have more influence or information over how the packet is or was sent I added two methods: 
- send_enhanced() that return or take a struct respectively where the user can request the packet to be sent via a certain channel (possibly there might be other settings later on but I can't think of any right now to be honest).
- receive_enhanced() where the user can see via which channel the packet was received

Of course there would be more convenient APIs if it would be a common usecase to open several data channels where each has its own specific settings and use cases but I love matchbox for its simplicity and this is I think the simplest API for simple use cases.

Please let me know what you think and if this is going more in a direction that is convenient for you as well.