### PR TITLE
Fix regression in wasm connections behind NATs

### DIFF
--- a/matchbox_socket/Cargo.toml
+++ b/matchbox_socket/Cargo.toml
@@ -40,6 +40,7 @@ web-sys = { version = "0.3.22", default-features = false, features = [
     "RtcPeerConnection",
     "RtcSdpType", "RtcSessionDescription", "RtcSessionDescriptionInit",
     "RtcIceGatheringState", "RtcIceCandidate", "RtcIceCandidateInit", "RtcPeerConnectionIceEvent",
+    "RtcIceConnectionState",
     "RtcConfiguration", "RtcDataChannel", "RtcDataChannelInit", "RtcDataChannelType",
 ] }
 serde-wasm-bindgen = { version = "0.4" }

--- a/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
@@ -245,7 +245,12 @@ async fn handshake_offer(
     // TODO: we should support getting new ICE candidates even after connecting,
     //       since it's possible to return to the ice gathering state
     // See: <https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/iceGatheringState>
-    conn.set_onicecandidate(None);
+    let onicecandidate: Box<dyn FnMut(RtcPeerConnectionIceEvent)> =
+        Box::new(move |_event: RtcPeerConnectionIceEvent| {
+            warn!("received ice candidate event after handshake completed");
+        });
+    let onicecandidate = Closure::wrap(onicecandidate);
+    conn.set_onicecandidate(Some(onicecandidate.as_ref().unchecked_ref()));
 
     debug!("Ice completed: {:?}", conn.ice_gathering_state());
 
@@ -391,7 +396,12 @@ async fn handshake_accept(
     // TODO: we should support getting new ICE candidates even after connecting,
     //       since it's possible to return to the ice gathering state
     // See: <https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/iceGatheringState>
-    conn.set_onicecandidate(None);
+    let onicecandidate: Box<dyn FnMut(RtcPeerConnectionIceEvent)> =
+        Box::new(move |_event: RtcPeerConnectionIceEvent| {
+            warn!("received ice candidate event after handshake completed");
+        });
+    let onicecandidate = Closure::wrap(onicecandidate);
+    conn.set_onicecandidate(Some(onicecandidate.as_ref().unchecked_ref()));
 
     debug!("Ice completed: {:?}", conn.ice_gathering_state());
 

--- a/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
@@ -425,7 +425,20 @@ fn create_rtc_peer_connection(config: &WebRtcSocketConfig) -> RtcPeerConnection 
     };
     let ice_server_config_list = [ice_server_config];
     peer_config.ice_servers(&serde_wasm_bindgen::to_value(&ice_server_config_list).unwrap());
-    RtcPeerConnection::new_with_configuration(&peer_config).unwrap()
+    let connection = RtcPeerConnection::new_with_configuration(&peer_config).unwrap();
+
+    let connection_1 = connection.clone();
+    let oniceconnectionstatechange: Box<dyn FnMut(_)> = Box::new(move |_event: JsValue| {
+        debug!(
+            "ice connection state changed: {:?}",
+            connection_1.ice_connection_state()
+        );
+    });
+    let oniceconnectionstatechange = Closure::wrap(oniceconnectionstatechange);
+    connection
+        .set_oniceconnectionstatechange(Some(oniceconnectionstatechange.as_ref().unchecked_ref()));
+
+    connection
 }
 
 fn create_data_channel(

--- a/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
@@ -218,6 +218,8 @@ async fn handshake_offer(
     );
     let onicecandidate = Closure::wrap(onicecandidate);
     conn.set_onicecandidate(Some(onicecandidate.as_ref().unchecked_ref()));
+    // note: we can let rust keep ownership of this closure, since we replace
+    // the event handler later in this method when ice is finished
 
     // handle pending ICE candidates
     for candidate in received_candidates {
@@ -252,6 +254,7 @@ async fn handshake_offer(
         });
     let onicecandidate = Closure::wrap(onicecandidate);
     conn.set_onicecandidate(Some(onicecandidate.as_ref().unchecked_ref()));
+    onicecandidate.forget();
 
     debug!("Ice completed: {:?}", conn.ice_gathering_state());
 
@@ -376,6 +379,8 @@ async fn handshake_accept(
     );
     let onicecandidate = Closure::wrap(onicecandidate);
     conn.set_onicecandidate(Some(onicecandidate.as_ref().unchecked_ref()));
+    // note: we can let rust keep ownership of this closure, since we replace
+    // the event handler later in this method when ice is finished
 
     // handle pending ICE candidates
     for candidate in received_candidates {
@@ -410,6 +415,7 @@ async fn handshake_accept(
         });
     let onicecandidate = Closure::wrap(onicecandidate);
     conn.set_onicecandidate(Some(onicecandidate.as_ref().unchecked_ref()));
+    onicecandidate.forget();
 
     debug!("Ice completed: {:?}", conn.ice_gathering_state());
 
@@ -445,6 +451,7 @@ fn create_rtc_peer_connection(config: &WebRtcSocketConfig) -> RtcPeerConnection 
     let oniceconnectionstatechange = Closure::wrap(oniceconnectionstatechange);
     connection
         .set_oniceconnectionstatechange(Some(oniceconnectionstatechange.as_ref().unchecked_ref()));
+    oniceconnectionstatechange.forget();
 
     connection
 }


### PR DESCRIPTION
Something in #54 broke connections between me and another peer (both of us behind NATs)

In this PR, we start sending null ice candidates, and add them on the receiving end. I'm not completely sure what the point of it is, but [MDN examples do this](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Simple_RTCDataChannel_sample) so it's probably best if we do it too.

Sadly, this alone wasn't enough to fix the regression. Adding back the wait for ice gathering to complete, however, did fix the issue. So that means that on wasm, we now have some weird frankenstein of ice-trickle and non-trickle, but the regression is gone, and cross-play still seems to work. So it's still better than before, and I'm really anxious to get a fix for the regression merged, even if it's ugly and I don't really understand how it fixes it.

If anyone has ideas about what could be wrong with the trickle implementation, please let me know.

Fixes: #58 

@rozgo 