### PR TITLE
Inline format argument

### DIFF
--- a/matchbox_demo/src/main.rs
+++ b/matchbox_demo/src/main.rs
@@ -162,7 +162,7 @@ fn lobby_system(
     socket.0.as_mut().unwrap().accept_new_connections();
     let connected_peers = socket.0.as_ref().unwrap().connected_peers().len();
     let remaining = args.players - (connected_peers + 1);
-    query.single_mut().sections[0].value = format!("Waiting for {} more player(s)", remaining);
+    query.single_mut().sections[0].value = format!("Waiting for {remaining} more player(s)",);
     if remaining > 0 {
         return;
     }


### PR DESCRIPTION
Fix `clippy` lints by inlining `remaining` players in waiting message