### PR TITLE
Replace Warp with Axum for the signalling server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2995,7 +2995,6 @@ dependencies = [
  "axum",
  "clap",
  "futures",
- "log",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4622,6 +4622,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3000,6 +3000,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
  "futures-util",
  "log",
  "pin-project-lite",
- "tungstenite 0.18.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -473,6 +473,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "axum"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3114e77b361ec716aa429ae5c04243abe00cf7548e870b9370affcc5c491a7d0"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "base64 0.20.0",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cae3e661676ffbacb30f1a824089a8c9150e71017f7e1e38f2aa32009188d34"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +551,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64ct"
@@ -679,7 +738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e853e346ba412354e02292c7aa5b9a9dccdfa748e273b1b7ebf8f6a172f89712"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.13.1",
  "bevy_app",
  "bevy_asset",
  "bevy_core",
@@ -1207,16 +1266,6 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-lite",
-]
-
-[[package]]
-name = "buf_redux"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
-dependencies = [
- "memchr",
- "safemem",
 ]
 
 [[package]]
@@ -2531,25 +2580,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2577,31 +2607,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
  "serde",
-]
-
-[[package]]
-name = "headers"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
-dependencies = [
- "base64",
- "bitflags",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
-dependencies = [
- "http",
 ]
 
 [[package]]
@@ -2711,6 +2716,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2741,7 +2752,6 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -2982,17 +2992,19 @@ dependencies = [
 name = "matchbox_server"
 version = "0.5.0"
 dependencies = [
+ "axum",
  "clap",
  "futures",
  "log",
- "pretty_env_logger",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
- "warp",
 ]
 
 [[package]]
@@ -3044,6 +3056,12 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "md-5"
@@ -3099,16 +3117,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3133,24 +3141,6 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "multipart"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182"
-dependencies = [
- "buf_redux",
- "httparse",
- "log",
- "mime",
- "mime_guess",
- "quick-error",
- "rand",
- "safemem",
- "tempfile",
- "twoway",
 ]
 
 [[package]]
@@ -3512,7 +3502,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -3861,15 +3851,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "renderdoc-sys"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3907,7 +3888,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300a51053b1cb55c80b7a9fde4120726ddf25ca241a1cbb926626f62fb136bff"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "serde",
 ]
@@ -3987,7 +3968,7 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "log",
  "ring",
  "sct",
@@ -3995,13 +3976,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "0.2.1"
+name = "rustversion"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
-dependencies = [
- "base64",
-]
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "ryu"
@@ -4017,12 +3995,6 @@ checksum = "c1ff3d6d9696af502cc3110dacce942840fb06ff4514cad92236ecc455f2ce05"
 dependencies = [
  "bytemuck",
 ]
-
-[[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "scoped-tls"
@@ -4145,6 +4117,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b04f22b563c91331a10074bda3dd5492e3cc39d56bd557e91c0af42b6c7341"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_qs"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4199,17 +4180,6 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.6",
 ]
 
 [[package]]
@@ -4375,7 +4345,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7e94b1ec00bad60e6410e058b52f1c66de3dc5fe4d62d09b3e52bb7d3b73e25"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "crc",
  "lazy_static",
  "md-5",
@@ -4421,6 +4391,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4443,20 +4419,6 @@ dependencies = [
  "hash32-derive",
  "num-traits",
  "typenum",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
-dependencies = [
- "cfg-if",
- "fastrand",
- "libc",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
 ]
 
 [[package]]
@@ -4608,28 +4570,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
+checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
 dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.17.3",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
- "tracing",
+ "tungstenite",
 ]
 
 [[package]]
@@ -4640,6 +4588,47 @@ checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
@@ -4735,30 +4724,11 @@ checksum = "0609f771ad9c6155384897e1df4d948e692667cc0588548b68eb44d052b27633"
 
 [[package]]
 name = "tungstenite"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
-dependencies = [
- "base64",
- "byteorder",
- "bytes",
- "http",
- "httparse",
- "log",
- "rand",
- "sha-1 0.10.1",
- "thiserror",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "http",
@@ -4778,7 +4748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4712ee30d123ec7ae26d1e1b218395a16c87cdbaf4b3925d170d684af62ea5e8"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "futures",
  "log",
  "md-5",
@@ -4791,28 +4761,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "twoway"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "unicode-bidi"
@@ -4948,37 +4900,6 @@ checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
  "log",
  "try-lock",
-]
-
-[[package]]
-name = "warp"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7b8be92646fc3d18b06147664ebc5f48d222686cb11a8755e561a735aacc6d"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "headers",
- "http",
- "hyper",
- "log",
- "mime",
- "mime_guess",
- "multipart",
- "percent-encoding",
- "pin-project",
- "rustls-pemfile",
- "scoped-tls",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-stream",
- "tokio-tungstenite",
- "tokio-util",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -5248,7 +5169,7 @@ dependencies = [
  "rustls",
  "sec1",
  "serde",
- "sha-1 0.9.8",
+ "sha-1",
  "sha2 0.9.9",
  "signature",
  "subtle",
@@ -5347,7 +5268,7 @@ dependencies = [
  "log",
  "rtcp",
  "rtp",
- "sha-1 0.9.8",
+ "sha-1",
  "subtle",
  "thiserror",
  "tokio",
@@ -5698,7 +5619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fb9bace5b5589ffead1afb76e43e34cff39cd0f3ce7e170ae0c29e53b88eb1c"
 dependencies = [
  "asn1-rs 0.3.1",
- "base64",
+ "base64 0.13.1",
  "data-encoding",
  "der-parser 7.0.0",
  "lazy_static",

--- a/matchbox_server/Cargo.toml
+++ b/matchbox_server/Cargo.toml
@@ -26,5 +26,4 @@ thiserror = "1.0"
 tokio-stream = "0.1"
 
 [dev-dependencies]
-tokio = { version = "1.10", features = ["macros", "rt-multi-thread", "time"] }
 tokio-tungstenite = "0.18.0"

--- a/matchbox_server/Cargo.toml
+++ b/matchbox_server/Cargo.toml
@@ -15,7 +15,7 @@ readme = "../README.md"
 axum = { version = "0.6", features = ["ws"] }
 tracing = { version = "0.1", features= ["log"] }
 tracing-subscriber = { version = "0.3", features=["env-filter"] }
-tower-http = { version = "0.3", features = ["cors"] }
+tower-http = { version = "0.3", features = ["cors", "trace"] }
 tokio = { version = "1.10", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/matchbox_server/Cargo.toml
+++ b/matchbox_server/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../README.md"
 [dependencies]
 axum = { version = "0.6", features = ["ws"] }
 tracing = { version = "0.1", features= ["log"] }
-tracing-subscriber = { version = "0.3", features=["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tower-http = { version = "0.3", features = ["cors", "trace"] }
 tokio = { version = "1.10", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/matchbox_server/Cargo.toml
+++ b/matchbox_server/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 
 [dependencies]
 axum = { version = "0.6", features = ["ws"] }
-tracing = { version = "0.1", features= ["log"] }
+tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tower-http = { version = "0.3", features = ["cors", "trace"] }
 tokio = { version = "1.10", features = ["macros", "rt-multi-thread"] }

--- a/matchbox_server/Cargo.toml
+++ b/matchbox_server/Cargo.toml
@@ -24,7 +24,6 @@ uuid = { version = "1.0", features = ["serde", "v4"] }
 clap = { version = "4.0", features = ["derive", "env"] }
 thiserror = "1.0"
 tokio-stream = "0.1"
-log = "0.4"
 
 [dev-dependencies]
 tokio = { version = "1.10", features = ["macros", "rt-multi-thread", "time"] }

--- a/matchbox_server/Cargo.toml
+++ b/matchbox_server/Cargo.toml
@@ -12,14 +12,16 @@ homepage = "https://github.com/johanhelsing/matchbox"
 readme = "../README.md"
 
 [dependencies]
-warp = "0.3.1"
+axum = { version = "0.6", features = ["ws"] }
+tracing = { version = "0.1", features= ["log"] }
+tracing-subscriber = { version = "0.3", features=["env-filter"] }
+tower-http = { version = "0.3", features = ["cors"] }
 tokio = { version = "1.10", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 uuid = { version = "1.0", features = ["serde", "v4"] }
 clap = { version = "4.0", features = ["derive", "env"] }
-pretty_env_logger = "0.4"
 thiserror = "1.0"
 tokio-stream = "0.1"
 log = "0.4"

--- a/matchbox_server/Cargo.toml
+++ b/matchbox_server/Cargo.toml
@@ -27,3 +27,4 @@ tokio-stream = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1.10", features = ["macros", "rt-multi-thread", "time"] }
+tokio-tungstenite = "0.18.0"

--- a/matchbox_server/src/error.rs
+++ b/matchbox_server/src/error.rs
@@ -1,0 +1,28 @@
+use axum::extract::ws::Message;
+use tokio::sync::mpsc::error::SendError;
+
+/// An error derived from a client's request.
+#[derive(Debug, thiserror::Error)]
+pub enum ClientRequestError {
+    #[error("Axum error")]
+    Axum(#[from] axum::Error),
+    #[error("Not text error")]
+    NotText,
+    #[error("Message is close")]
+    Close,
+    #[error("Json error")]
+    Json(#[from] serde_json::Error),
+    #[error("Unsupported message type")]
+    UnsupportedType,
+}
+
+/// An error in server logic.
+#[derive(Debug, thiserror::Error)]
+pub enum ServerError {
+    #[error("Axum error")]
+    Axum(#[from] axum::Error),
+    #[error("Unknown recipient peer")]
+    UnknownPeer,
+    #[error("Undeliverable message")]
+    Undeliverable(#[from] SendError<Result<Message, axum::Error>>),
+}

--- a/matchbox_server/src/error.rs
+++ b/matchbox_server/src/error.rs
@@ -6,8 +6,6 @@ use tokio::sync::mpsc::error::SendError;
 pub enum ClientRequestError {
     #[error("Axum error")]
     Axum(#[from] axum::Error),
-    #[error("Not text error")]
-    NotText,
     #[error("Message is close")]
     Close,
     #[error("Json error")]

--- a/matchbox_server/src/error.rs
+++ b/matchbox_server/src/error.rs
@@ -19,8 +19,6 @@ pub enum ClientRequestError {
 /// An error in server logic.
 #[derive(Debug, thiserror::Error)]
 pub enum ServerError {
-    #[error("Axum error")]
-    Axum(#[from] axum::Error),
     #[error("Unknown recipient peer")]
     UnknownPeer,
     #[error("Undeliverable message")]

--- a/matchbox_server/src/main.rs
+++ b/matchbox_server/src/main.rs
@@ -42,7 +42,6 @@ async fn main() {
     let server_state = Arc::new(futures::lock::Mutex::new(ServerState::default()));
     let app = Router::new()
         .route("/health", get(health_handler))
-        .route("/", get(ws_handler))
         .route("/:room_id", get(ws_handler))
         .layer(
             // Allow requests from anywhere - Not ideal for production!

--- a/matchbox_server/src/main.rs
+++ b/matchbox_server/src/main.rs
@@ -60,7 +60,7 @@ async fn main() {
         .with_state(server_state);
 
     // Run server
-    info!("Matchbox Signaling Server: {}", args.host,);
+    info!("Matchbox Signaling Server: {}", args.host);
     axum::Server::bind(&args.host)
         .serve(app.into_make_service_with_connect_info::<SocketAddr>())
         .await

--- a/matchbox_server/src/main.rs
+++ b/matchbox_server/src/main.rs
@@ -16,6 +16,7 @@ pub use signaling::matchbox::PeerId;
 use crate::signaling::{ws_handler, ServerState};
 
 mod args;
+pub(crate) mod error;
 mod signaling;
 
 #[tokio::main]

--- a/matchbox_server/src/main.rs
+++ b/matchbox_server/src/main.rs
@@ -16,7 +16,7 @@ pub use signaling::matchbox::PeerId;
 use crate::signaling::{ws_handler, ServerState};
 
 mod args;
-pub(crate) mod error;
+mod error;
 mod signaling;
 
 #[tokio::main]

--- a/matchbox_server/src/main.rs
+++ b/matchbox_server/src/main.rs
@@ -2,13 +2,12 @@ use axum::response::IntoResponse;
 use axum::Router;
 use axum::{http::StatusCode, routing::get};
 use clap::Parser;
-use log::info;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::trace::{DefaultOnResponse, TraceLayer};
 use tower_http::LatencyUnit;
-use tracing::Level;
+use tracing::{info, Level};
 use tracing_subscriber::prelude::*;
 
 pub use args::Args;

--- a/matchbox_server/src/signaling.rs
+++ b/matchbox_server/src/signaling.rs
@@ -156,7 +156,7 @@ fn parse_request(request: Result<Message, Error>) -> Result<PeerRequest, Request
         Message::Text(text) => serde_json::from_str(&text)?,
         Message::Binary(_) => return Err(RequestError::NotText),
         Message::Close(_) => return Err(RequestError::Close),
-        _ => unimplemented!("unsupported message"),
+        Message::Ping(_) | Message::Pong(_) => unimplemented!("unsupported message"),
     };
 
     Ok(request)

--- a/matchbox_server/src/signaling.rs
+++ b/matchbox_server/src/signaling.rs
@@ -90,7 +90,8 @@ impl ServerState {
         }
     }
 
-    /// Remove a peer from the state, returning the peer removed.
+    /// Remove a peer from the state if it existed, returning the peer removed.
+    #[must_use]
     fn remove_peer(&mut self, peer_id: &PeerId) -> Option<Peer> {
         let peer = self.clients.remove(peer_id);
 

--- a/matchbox_server/src/signaling.rs
+++ b/matchbox_server/src/signaling.rs
@@ -147,6 +147,8 @@ enum RequestError {
     Close,
     #[error("Json error")]
     Json(#[from] serde_json::Error),
+    #[error("Unsupported message type")]
+    UnsupportedType,
 }
 
 fn parse_request(request: Result<Message, Error>) -> Result<PeerRequest, RequestError> {
@@ -156,7 +158,7 @@ fn parse_request(request: Result<Message, Error>) -> Result<PeerRequest, Request
         Message::Text(text) => serde_json::from_str(&text)?,
         Message::Binary(_) => return Err(RequestError::NotText),
         Message::Close(_) => return Err(RequestError::Close),
-        Message::Ping(_) | Message::Pong(_) => unimplemented!("unsupported message"),
+        _ => return Err(RequestError::UnsupportedType),
     };
 
     Ok(request)

--- a/matchbox_server/src/signaling.rs
+++ b/matchbox_server/src/signaling.rs
@@ -94,14 +94,14 @@ impl ServerState {
     fn remove_peer(&mut self, peer_id: &PeerId) -> Option<Peer> {
         let peer = self.clients.remove(peer_id);
 
-        if let Some(peer) = peer {
+        if let Some(ref peer) = peer {
             // Best effort to remove peer from their room
             _ = self
                 .rooms
                 .get_mut(&peer.room)
                 .map(|room| room.remove(peer_id));
         }
-        Ok(peer)
+        peer
     }
 
     /// Send a message to a peer without blocking.
@@ -248,7 +248,7 @@ async fn handle_ws(
     info!("Removing peer: {:?}", peer_uuid);
     if let Some(uuid) = peer_uuid {
         let mut state = state.lock().await;
-        if let None = state.remove_peer(&uuid) {
+        if state.remove_peer(&uuid).is_none() {
             error!("couldn't remove {uuid}, not found");
         }
     }

--- a/matchbox_server/src/signaling.rs
+++ b/matchbox_server/src/signaling.rs
@@ -144,7 +144,6 @@ fn parse_request(request: Result<Message, Error>) -> Result<PeerRequest, ClientR
 
     let request: PeerRequest = match request {
         Message::Text(text) => serde_json::from_str(&text)?,
-        Message::Binary(_) => return Err(ClientRequestError::NotText),
         Message::Close(_) => return Err(ClientRequestError::Close),
         _ => return Err(ClientRequestError::UnsupportedType),
     };

--- a/matchbox_server/src/signaling.rs
+++ b/matchbox_server/src/signaling.rs
@@ -154,7 +154,7 @@ fn parse_request(request: Result<Message, Error>) -> Result<PeerRequest, ClientR
 
 fn spawn_sender_task(
     sender: SplitSink<WebSocket, Message>,
-) -> mpsc::UnboundedSender<std::result::Result<Message, Error>> {
+) -> mpsc::UnboundedSender<Result<Message, Error>> {
     let (client_sender, receiver) = mpsc::unbounded_channel();
     tokio::task::spawn(UnboundedReceiverStream::new(receiver).forward(sender));
     client_sender

--- a/matchbox_server/src/signaling.rs
+++ b/matchbox_server/src/signaling.rs
@@ -4,13 +4,13 @@ use axum::extract::{Path, Query, State};
 use axum::response::IntoResponse;
 use axum::Error;
 use futures::{lock::Mutex, stream::SplitSink, StreamExt};
-use log::{error, info, warn};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
+use tracing::{error, info, warn};
 
 pub mod matchbox {
     use serde::{Deserialize, Serialize};

--- a/matchbox_server/src/signaling.rs
+++ b/matchbox_server/src/signaling.rs
@@ -283,7 +283,8 @@ mod tests {
 
     // Helper to take the next PeerEvent from a stream
     async fn recv_peer_event(client: &mut WebSocketStream<MaybeTlsStream<TcpStream>>) -> PeerEvent {
-        let message: Message = futures::StreamExt::next(client)
+        let message: Message = client
+            .next()
             .await
             .expect("some message")
             .expect("socket message");

--- a/matchbox_server/src/signaling.rs
+++ b/matchbox_server/src/signaling.rs
@@ -126,7 +126,7 @@ pub(crate) async fn ws_handler(
     State(state): State<Arc<Mutex<ServerState>>>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
 ) -> impl IntoResponse {
-    println!("`{addr}` connected.");
+    info!("`{addr}` connected.");
 
     let room_id = room_id.map(|path| path.0).unwrap_or_default();
     let next = params

--- a/matchbox_simple_demo/src/main.rs
+++ b/matchbox_simple_demo/src/main.rs
@@ -25,7 +25,7 @@ async fn main() {
 
 async fn async_main() {
     info!("Connecting to matchbox");
-    let (mut socket, loop_fut) = WebRtcSocket::new("ws://localhost:3536/");
+    let (mut socket, loop_fut) = WebRtcSocket::new("ws://localhost:3536/example_room");
 
     info!("my id is {:?}", socket.id());
 

--- a/matchbox_simple_demo/src/main.rs
+++ b/matchbox_simple_demo/src/main.rs
@@ -25,7 +25,7 @@ async fn main() {
 
 async fn async_main() {
     info!("Connecting to matchbox");
-    let (mut socket, loop_fut) = WebRtcSocket::new("ws://localhost:3536/example_room");
+    let (mut socket, loop_fut) = WebRtcSocket::new("ws://localhost:3536/");
 
     info!("my id is {:?}", socket.id());
 


### PR DESCRIPTION
It's no secret Warp is losing the server framework battle to Axum, so this will be the first step towards modernizing the architecture.

This is a draft to replace Warp with Axum for the signalling server. Another opinion I made was to use `tracing`/`tracing_subscriber` over `pretty_env_logger` for logging, for similar reasons.

This is a total drop-in replacement. All metrics being logged and all route rules are preserved, with no impact to demos or the user.