### PR TITLE
a possible way of handling disconnected peers

### DIFF
--- a/matchbox_simple_demo/src/main.rs
+++ b/matchbox_simple_demo/src/main.rs
@@ -46,6 +46,11 @@ async fn async_main() {
             info!("Received from {:?}: {:?}", peer, packet);
         }
 
+        let disconnected_peers = socket.disconnected_peers();
+        if disconnected_peers.len() > 0 {
+            info!("Disconnected peers: {:?}", disconnected_peers);
+        }
+
         select! {
             _ = (&mut timeout).fuse() => {
                 timeout.reset(Duration::from_millis(100));

--- a/matchbox_socket/src/webrtc_socket/messages.rs
+++ b/matchbox_socket/src/webrtc_socket/messages.rs
@@ -6,6 +6,7 @@ pub(crate) type PeerId = String;
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum PeerEvent {
     NewPeer(PeerId),
+    PeerLeft(PeerId),
     Signal { sender: PeerId, data: PeerSignal },
 }
 

--- a/matchbox_socket/src/webrtc_socket/native/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/native/message_loop.rs
@@ -38,6 +38,7 @@ pub async fn message_loop(
     events_receiver: futures_channel::mpsc::UnboundedReceiver<PeerEvent>,
     peer_messages_out_rx: Vec<futures_channel::mpsc::UnboundedReceiver<(PeerId, Packet)>>,
     new_connected_peers_tx: futures_channel::mpsc::UnboundedSender<PeerId>,
+    disconnected_peers_tx: futures_channel::mpsc::UnboundedSender<PeerId>,
     messages_from_peers_tx: Vec<futures_channel::mpsc::UnboundedSender<(PeerId, Packet)>>,
 ) {
     message_loop_impl(
@@ -47,6 +48,7 @@ pub async fn message_loop(
         events_receiver,
         peer_messages_out_rx,
         new_connected_peers_tx,
+        disconnected_peers_tx,
         messages_from_peers_tx,
     )
     // web-rtc is tokio-based so we use compat here to make it work with other async run-times
@@ -61,6 +63,7 @@ async fn message_loop_impl(
     mut events_receiver: futures_channel::mpsc::UnboundedReceiver<PeerEvent>,
     mut peer_messages_out_rx: Vec<futures_channel::mpsc::UnboundedReceiver<(PeerId, Packet)>>,
     new_connected_peers_tx: futures_channel::mpsc::UnboundedSender<PeerId>,
+    disconnected_peers_tx: futures_channel::mpsc::UnboundedSender<PeerId>,
     messages_from_peers_tx: Vec<futures_channel::mpsc::UnboundedSender<(PeerId, Packet)>>,
 ) {
     debug!("Entering native WebRtcSocket message loop");
@@ -112,6 +115,9 @@ async fn message_loop_impl(
 
                             connected_peers.insert(peer_uuid, to_peer_data_tx);
                             peer_loops_a.push(peer_loop(handshake_fut, to_peer_data_rx));
+                        }
+                        PeerEvent::PeerLeft(peer_uuid) => {
+                            disconnected_peers_tx.unbounded_send(peer_uuid).expect("fail to send disconnected peer");
                         }
                         PeerEvent::Signal { sender, data } => {
                             let from_peer_sender = handshake_signals.entry(sender.clone()).or_insert_with(|| {


### PR DESCRIPTION
This is one way of handling disconnected peers that seems to work in our case. For issue #81 

Calling:
`pub fn disconnected_peers(&mut self) -> Vec<PeerId> `
cleans up peers and returns disconnected peers. Needs to be called any time the API user wants to clean up peers.

Not sure how to handle when GGRS takes over the socket. Could potentially handle this in `log_ggrs_events` if the socket is accessible.

Anyway, just a possible solution. 