### PR TITLE
Begin error propogation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3040,6 +3040,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
+ "thiserror",
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2327,6 +2327,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
+name = "futures-test"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b57590ad76d93051b7024d7cca00ada0d6521f6e71ecef9516141ebefcb9998"
+dependencies = [
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+ "pin-project",
+ "pin-utils",
+]
+
+[[package]]
 name = "futures-timer"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3032,6 +3049,7 @@ dependencies = [
  "bytes",
  "futures",
  "futures-channel",
+ "futures-test",
  "futures-timer",
  "futures-util",
  "ggrs",

--- a/matchbox_socket/Cargo.toml
+++ b/matchbox_socket/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 uuid = { version = "1.0", default-features = false, features = ["v4"] }
 log = { version = "0.4", default-features = false }
+thiserror = "1.0"
 
 # ggrs-socket
 ggrs = { version = "0.9.3", default-features = false, optional = true }

--- a/matchbox_socket/Cargo.toml
+++ b/matchbox_socket/Cargo.toml
@@ -51,3 +51,6 @@ async-tungstenite = { version = "0.19", default-features = false, features = [ "
 webrtc = { version = "0.6", default-features = false }
 bytes = { version = "1.1", default-features = false }
 async-compat = { version = "0.2.1", default-features = false }
+
+[dev-dependencies]
+futures-test = { version = "0.3" }

--- a/matchbox_socket/src/error.rs
+++ b/matchbox_socket/src/error.rs
@@ -3,7 +3,7 @@ use crate::webrtc_socket::error::SignallingError;
 /// Errors that can happen when using Matchbox.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// An error ocurring during the signalling loop.
+    /// An error occurring during the signalling loop.
     #[error("An error in the signalling loop")]
     Signalling(#[from] SignallingError),
 }

--- a/matchbox_socket/src/error.rs
+++ b/matchbox_socket/src/error.rs
@@ -1,0 +1,9 @@
+use crate::webrtc_socket::error::SignallingError;
+
+/// Errors that can happen when using Matchbox.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// An error ocurring during the signalling loop.
+    #[error("An error in the signalling loop")]
+    Signalling(#[from] SignallingError),
+}

--- a/matchbox_socket/src/lib.rs
+++ b/matchbox_socket/src/lib.rs
@@ -2,8 +2,10 @@
 #![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)]
 
+mod error;
 #[cfg(feature = "ggrs-socket")]
 mod ggrs_socket;
 mod webrtc_socket;
 
+pub use error::Error;
 pub use webrtc_socket::{ChannelConfig, RtcIceServerConfig, WebRtcSocket, WebRtcSocketConfig};

--- a/matchbox_socket/src/webrtc_socket/error.rs
+++ b/matchbox_socket/src/webrtc_socket/error.rs
@@ -1,0 +1,13 @@
+/// An error that can occur with WebRTC signalling.
+#[derive(Debug, thiserror::Error)]
+pub enum SignallingError {
+    #[cfg(not(target_arch = "wasm32"))]
+    #[error("Failed to connect to signalling server")]
+    Unreachable(#[from] async_tungstenite::tungstenite::Error),
+    #[cfg(target_arch = "wasm32")]
+    #[error("Failed to connect to signalling server")]
+    Unreachable(#[from] ws_stream_wasm::WsErr),
+    #[cfg(target_arch = "wasm32")]
+    #[error("The stream is exhausted")]
+    StreamExhausted,
+}

--- a/matchbox_socket/src/webrtc_socket/error.rs
+++ b/matchbox_socket/src/webrtc_socket/error.rs
@@ -1,13 +1,19 @@
 /// An error that can occur with WebRTC signalling.
 #[derive(Debug, thiserror::Error)]
 pub enum SignallingError {
-    #[cfg(not(target_arch = "wasm32"))]
-    #[error("Failed to connect to signalling server")]
-    Unreachable(#[from] async_tungstenite::tungstenite::Error),
-    #[cfg(target_arch = "wasm32")]
-    #[error("Failed to connect to signalling server")]
-    Unreachable(#[from] ws_stream_wasm::WsErr),
-    #[cfg(target_arch = "wasm32")]
+    // Common
+    #[error("failed to send event to signalling server")]
+    Undeliverable(#[from] futures_channel::mpsc::TrySendError<super::messages::PeerEvent>),
     #[error("The stream is exhausted")]
     StreamExhausted,
+
+    // Native
+    #[cfg(not(target_arch = "wasm32"))]
+    #[error("socket failure communicating with signalling server")]
+    Socket(#[from] async_tungstenite::tungstenite::Error),
+
+    // WASM
+    #[cfg(target_arch = "wasm32")]
+    #[error("socket failure communicating with signalling server")]
+    Socket(#[from] ws_stream_wasm::WsErr),
 }

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -424,3 +424,18 @@ async fn wait_for_ready(channel_ready_rx: Vec<futures_channel::mpsc::Receiver<u8
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::{Error, WebRtcSocket};
+
+    #[futures_test::test]
+    async fn unreachable_server() {
+        // .invalid is a reserved tld for testing and documentation
+        let (_socket, fut) = WebRtcSocket::new("wss://invalid.xyz");
+
+        let result = fut.await;
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::Signalling(_)));
+    }
+}

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -432,7 +432,7 @@ mod test {
     #[futures_test::test]
     async fn unreachable_server() {
         // .invalid is a reserved tld for testing and documentation
-        let (_socket, fut) = WebRtcSocket::new("wss://invalid.xyz");
+        let (_socket, fut) = WebRtcSocket::new("wss://example.invalid");
 
         let result = fut.await;
         assert!(result.is_err());

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -1,10 +1,11 @@
 use futures::{future::Fuse, stream::FusedStream, Future, FutureExt, StreamExt};
 use futures_channel::mpsc::{UnboundedReceiver, UnboundedSender};
 use futures_util::select;
-use log::debug;
+use log::{debug, error};
 use messages::*;
 use std::pin::Pin;
 use uuid::Uuid;
+pub(crate) mod error;
 mod messages;
 mod signal_peer;
 
@@ -370,9 +371,14 @@ async fn run_socket(
                 break;
             }
 
-            _ = signalling_loop_done => {
-                debug!("Signalling loop completed");
-                // todo!{"reconnect?"}
+            sigloop = signalling_loop_done => {
+                match sigloop {
+                    Ok(()) => debug!("Signalling loop completed"),
+                    Err(e) => {
+                        error!("{e:?}");
+                        // TODO: Reconnect X attempts if configured to reconnect.
+                    },
+                }
             }
 
             complete => break

--- a/matchbox_socket/src/webrtc_socket/native/signalling_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/native/signalling_loop.rs
@@ -55,18 +55,3 @@ pub async fn signalling_loop(
         }
     }
 }
-
-#[cfg(all(test, not(target_arch = "wasm32-unknown-unknown")))]
-mod test {
-    use crate::{Error, WebRtcSocket};
-
-    #[futures_test::test]
-    async fn unreachable_server() {
-        // .invalid is a reserved tld for testing and documentation
-        let (_socket, fut) = WebRtcSocket::new("wss://invalid.xyz");
-
-        let result = fut.await;
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::Signalling(_)));
-    }
-}

--- a/matchbox_socket/src/webrtc_socket/native/signalling_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/native/signalling_loop.rs
@@ -55,3 +55,18 @@ pub async fn signalling_loop(
         }
     }
 }
+
+#[cfg(all(test, not(target_arch = "wasm32-unknown-unknown")))]
+mod test {
+    use crate::{Error, WebRtcSocket};
+
+    #[futures_test::test]
+    async fn unreachable_server() {
+        // .invalid is a reserved tld for testing and documentation
+        let (_socket, fut) = WebRtcSocket::new("wss://invalid.xyz");
+
+        let result = fut.await;
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::Signalling(_)));
+    }
+}

--- a/matchbox_socket/src/webrtc_socket/native/signalling_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/native/signalling_loop.rs
@@ -5,7 +5,7 @@ use crate::webrtc_socket::{
 use async_tungstenite::{async_std::connect_async, tungstenite::Message};
 use futures::{pin_mut, FutureExt, SinkExt, StreamExt};
 use futures_util::select;
-use log::{debug, warn};
+use log::{debug, error, warn};
 
 pub async fn signalling_loop(
     room_url: String,

--- a/matchbox_socket/src/webrtc_socket/wasm/signalling_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm/signalling_loop.rs
@@ -12,6 +12,7 @@ pub async fn signalling_loop(
     let (_ws, wsio) = WsMeta::connect(&room_url, None)
         .await
         .map_err(SignallingError::from)?;
+
     let mut wsio = wsio.fuse();
 
     loop {


### PR DESCRIPTION
This PR is very focused on solving #93, but would also lay the groundwork for error propagation in support of #91 and #5.

I wish to "fail fast" if this method of error propagation is undesired, although I don't note anything controversial (avoiding another "second thoughts" re: #88). If this is approved I'll begin work on further error propagation.

In summary:
- Matchbox gets a root level `Error` type.
- The error library chosen is `thiserror`, to keep parity with the `matchbox_server`'s error library.
- WASM/Native Errors are configured in `webrtc_socket/error.rs` and enabled through cfg-directives (cfg-if would help here).