### PR TITLE
Add test for connecting to an unreachable server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2327,6 +2327,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
+name = "futures-test"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b57590ad76d93051b7024d7cca00ada0d6521f6e71ecef9516141ebefcb9998"
+dependencies = [
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+ "pin-project",
+ "pin-utils",
+]
+
+[[package]]
 name = "futures-timer"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3032,6 +3049,7 @@ dependencies = [
  "bytes",
  "futures",
  "futures-channel",
+ "futures-test",
  "futures-timer",
  "futures-util",
  "ggrs",

--- a/matchbox_socket/Cargo.toml
+++ b/matchbox_socket/Cargo.toml
@@ -50,3 +50,4 @@ async-tungstenite = { version = "0.19", default-features = false, features = [ "
 webrtc = { version = "0.6", default-features = false }
 bytes = { version = "1.1", default-features = false }
 async-compat = { version = "0.2.1", default-features = false }
+futures-test = { version = "0.3" }

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -408,3 +408,18 @@ async fn wait_for_ready(channel_ready_rx: Vec<futures_channel::mpsc::Receiver<u8
         }
     }
 }
+
+#[cfg(all(test, not(target_arch = "wasm32-unknown-unknown")))]
+mod test {
+    use crate::WebRtcSocket;
+
+    #[futures_test::test]
+    async fn unreachable_server() {
+        // .invalid is a reserved tld for testing and documentation
+        let (_socket, fut) = WebRtcSocket::new("wss://matchbox.invalid");
+
+        let _ = fut.await; // should not panic
+
+        // todo: assert on actual error returned
+    }
+}


### PR DESCRIPTION
Includes the test for #93, but not the fix.

- [ ] Can we make it run on wasm as well without having to write another set of test (maybe use wasm-bindgen-test conditionally somehow?)
- [ ] Make sure #93 is fixed first
- [ ] Make some assertions on what kind of error is returned?