### PR TITLE
Minor cleanups

### DIFF
--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -241,8 +241,7 @@ impl WebRtcSocket {
         }
         // If the channel dropped or becomes terminated, flush all peers
         if self.disconnected_peers.is_terminated() {
-            ids.extend(self.peers.clone());
-            self.peers.clear();
+            ids.append(&mut self.peers);
         }
         ids
     }

--- a/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm/message_loop.rs
@@ -635,18 +635,15 @@ fn check(res: &Result<(PeerId, Vec<RtcDataChannel>), Box<dyn std::error::Error>>
     res.as_ref().expect("handshake failed");
 }
 
-// The bellow is just to wrap Result<JsValue, JsValue> into something sensible-ish
+// The below is just to wrap Result<JsValue, JsValue> into something sensible-ish
 
 trait JsErrorExt<T> {
-    fn efix(self) -> Result<T, Box<dyn std::error::Error>>;
+    fn efix(self) -> Result<T, JsError>;
 }
 
 impl<T> JsErrorExt<T> for Result<T, JsValue> {
-    fn efix(self) -> Result<T, Box<dyn std::error::Error>> {
-        self.map_err(|e| {
-            let e: Box<dyn std::error::Error> = Box::new(JsError(e));
-            e
-        })
+    fn efix(self) -> Result<T, JsError> {
+        self.map_err(JsError)
     }
 }
 


### PR DESCRIPTION
We should perhaps just replace our `JsError` with `gloo_utils::errors::JsError`, but before that, this at least makes it slightly less hacky without introducing a dependency and easier to see what's really needed/going on.