### PR TITLE
Have server produce `PeerId`

### DIFF
--- a/matchbox_demo/src/main.rs
+++ b/matchbox_demo/src/main.rs
@@ -170,10 +170,10 @@ fn lobby_system(
     info!("All peers have joined, going in-game");
 
     // consume the socket (currently required because ggrs takes ownership of its socket)
-    let socket = socket.0.take().unwrap();
+    let mut socket = socket.0.take().unwrap();
 
     // extract final player list
-    let players = socket.players();
+    let players = socket.players().unwrap();
 
     let max_prediction = 12;
 

--- a/matchbox_simple_demo/src/main.rs
+++ b/matchbox_simple_demo/src/main.rs
@@ -33,8 +33,6 @@ async fn async_main() {
     info!("Connecting to matchbox");
     let (mut socket, loop_fut) = WebRtcSocket::new_unreliable("ws://localhost:3536/example_room");
 
-    info!("my id is {:?}", socket.id());
-
     let loop_fut = loop_fut.fuse();
     futures::pin_mut!(loop_fut);
 

--- a/matchbox_socket/src/ggrs_socket.rs
+++ b/matchbox_socket/src/ggrs_socket.rs
@@ -1,17 +1,18 @@
 use ggrs::{Message, PlayerType};
 
-use crate::WebRtcSocket;
+use crate::{webrtc_socket::error::UnknownPeerId, WebRtcSocket};
 
 impl WebRtcSocket {
     /// Returns a Vec of connected peers as [`ggrs::PlayerType`]
     #[must_use]
-    pub fn players(&self) -> Vec<PlayerType<String>> {
-        let client_id = self.get_id().unwrap().expect("Client has no ID.");
+    pub fn players(&mut self) -> Result<Vec<PlayerType<String>>, UnknownPeerId> {
+        let client_id = self.id().ok_or(UnknownPeerId)?;
         // needs to be consistent order across all peers
         let mut ids = self.connected_peers();
         ids.push(client_id.to_owned());
         ids.sort();
-        ids.iter()
+        let players = ids
+            .iter()
             .map(|id| {
                 if *id == client_id {
                     PlayerType::Local
@@ -19,7 +20,8 @@ impl WebRtcSocket {
                     PlayerType::Remote(id.to_owned())
                 }
             })
-            .collect()
+            .collect();
+        Ok(players)
     }
 }
 

--- a/matchbox_socket/src/ggrs_socket.rs
+++ b/matchbox_socket/src/ggrs_socket.rs
@@ -4,7 +4,6 @@ use crate::{webrtc_socket::error::UnknownPeerId, WebRtcSocket};
 
 impl WebRtcSocket {
     /// Returns a Vec of connected peers as [`ggrs::PlayerType`]
-    #[must_use]
     pub fn players(&mut self) -> Result<Vec<PlayerType<String>>, UnknownPeerId> {
         let client_id = self.id().ok_or(UnknownPeerId)?;
         // needs to be consistent order across all peers

--- a/matchbox_socket/src/ggrs_socket.rs
+++ b/matchbox_socket/src/ggrs_socket.rs
@@ -6,11 +6,19 @@ impl WebRtcSocket {
     /// Returns a Vec of connected peers as [`ggrs::PlayerType`]
     #[must_use]
     pub fn players(&self) -> Vec<PlayerType<String>> {
+        let client_id = self.get_id().unwrap().expect("Client has no ID.");
         // needs to be consistent order across all peers
-        self.connected_peers()
-            .iter()
-            .map(|id| PlayerType::Remote(id.clone()))
-            .chain([PlayerType::Local].into_iter())
+        let mut ids = self.connected_peers();
+        ids.push(client_id.to_owned());
+        ids.sort();
+        ids.iter()
+            .map(|id| {
+                if *id == client_id {
+                    PlayerType::Local
+                } else {
+                    PlayerType::Remote(id.to_owned())
+                }
+            })
             .collect()
     }
 }

--- a/matchbox_socket/src/ggrs_socket.rs
+++ b/matchbox_socket/src/ggrs_socket.rs
@@ -7,17 +7,10 @@ impl WebRtcSocket {
     #[must_use]
     pub fn players(&self) -> Vec<PlayerType<String>> {
         // needs to be consistent order across all peers
-        let mut ids = self.connected_peers();
-        ids.push(self.id().to_owned());
-        ids.sort();
-        ids.iter()
-            .map(|id| {
-                if id == self.id() {
-                    PlayerType::Local
-                } else {
-                    PlayerType::Remote(id.to_owned())
-                }
-            })
+        self.connected_peers()
+            .iter()
+            .map(|id| PlayerType::Remote(id.clone()))
+            .chain([PlayerType::Local].into_iter())
             .collect()
     }
 }

--- a/matchbox_socket/src/ggrs_socket.rs
+++ b/matchbox_socket/src/ggrs_socket.rs
@@ -1,6 +1,10 @@
 use ggrs::{Message, PlayerType};
 
-use crate::{webrtc_socket::error::UnknownPeerId, WebRtcSocket};
+use crate::WebRtcSocket;
+
+#[derive(Debug, thiserror::Error)]
+#[error("The client has not yet been given a Peer Id")]
+pub struct UnknownPeerId;
 
 impl WebRtcSocket {
     /// Returns a Vec of connected peers as [`ggrs::PlayerType`]

--- a/matchbox_socket/src/webrtc_socket/error.rs
+++ b/matchbox_socket/src/webrtc_socket/error.rs
@@ -1,6 +1,10 @@
 use crate::webrtc_socket::messages::PeerEvent;
 use futures_channel::mpsc::TrySendError;
 
+#[derive(Debug, thiserror::Error)]
+#[error("Peer Id is currently inaccesable")]
+pub struct UnretrievablePeerId;
+
 /// An error that can occur with WebRTC signalling.
 #[derive(Debug, thiserror::Error)]
 pub enum SignallingError {

--- a/matchbox_socket/src/webrtc_socket/error.rs
+++ b/matchbox_socket/src/webrtc_socket/error.rs
@@ -1,10 +1,6 @@
 use crate::webrtc_socket::messages::PeerEvent;
 use futures_channel::mpsc::TrySendError;
 
-#[derive(Debug, thiserror::Error)]
-#[error("The client has not yet been given a Peer Id")]
-pub struct UnknownPeerId;
-
 /// An error that can occur with WebRTC signalling.
 #[derive(Debug, thiserror::Error)]
 pub enum SignallingError {

--- a/matchbox_socket/src/webrtc_socket/error.rs
+++ b/matchbox_socket/src/webrtc_socket/error.rs
@@ -2,8 +2,8 @@ use crate::webrtc_socket::messages::PeerEvent;
 use futures_channel::mpsc::TrySendError;
 
 #[derive(Debug, thiserror::Error)]
-#[error("Peer Id is currently inaccesable")]
-pub struct UnretrievablePeerId;
+#[error("The client has not yet been given a Peer Id")]
+pub struct UnknownPeerId;
 
 /// An error that can occur with WebRTC signalling.
 #[derive(Debug, thiserror::Error)]

--- a/matchbox_socket/src/webrtc_socket/messages.rs
+++ b/matchbox_socket/src/webrtc_socket/messages.rs
@@ -5,6 +5,7 @@ pub(crate) type PeerId = String;
 /// Events go from signalling server to peer
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum PeerEvent {
+    IdAssigned(PeerId),
     NewPeer(PeerId),
     PeerLeft(PeerId),
     Signal { sender: PeerId, data: PeerSignal },
@@ -14,12 +15,7 @@ pub enum PeerEvent {
 /// Requests go from peer to signalling server
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum PeerRequest {
-    Uuid(PeerId),
-    Signal {
-        receiver: PeerId,
-        data: PeerSignal,
-    },
-    /// A routine packet to prevent idle websocket disconnection
+    Signal { receiver: PeerId, data: PeerSignal },
     KeepAlive,
 }
 

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -86,13 +86,9 @@ type Packet = Box<[u8]>;
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 trait Messenger {
-    async fn message_loop(id: PeerId, config: WebRtcSocketConfig, channels: MessageLoopChannels);
+    async fn message_loop(config: WebRtcSocketConfig, channels: MessageLoopChannels);
 }
 
-async fn message_loop<M: Messenger>(
-    id: PeerId,
-    config: WebRtcSocketConfig,
-    channels: MessageLoopChannels,
-) {
-    M::message_loop(id, config, channels).await
+async fn message_loop<M: Messenger>(config: WebRtcSocketConfig, channels: MessageLoopChannels) {
+    M::message_loop(config, channels).await
 }

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -1,19 +1,19 @@
+pub(crate) mod error;
 mod messages;
 mod signal_peer;
 mod socket;
-
-pub(crate) mod error;
-use std::pin::Pin;
 
 use crate::Error;
 use async_trait::async_trait;
 use cfg_if::cfg_if;
 use futures::{Future, FutureExt, StreamExt};
+use futures_util::lock::Mutex;
 use futures_util::select;
 use log::{debug, warn};
 use messages::*;
 pub(crate) use socket::MessageLoopChannels;
 pub use socket::{ChannelConfig, RtcIceServerConfig, WebRtcSocket, WebRtcSocketConfig};
+use std::{pin::Pin, sync::Arc};
 
 use self::error::SignallingError;
 
@@ -86,9 +86,17 @@ type Packet = Box<[u8]>;
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 trait Messenger {
-    async fn message_loop(config: WebRtcSocketConfig, channels: MessageLoopChannels);
+    async fn message_loop(
+        id: Arc<Mutex<Option<PeerId>>>,
+        config: WebRtcSocketConfig,
+        channels: MessageLoopChannels,
+    );
 }
 
-async fn message_loop<M: Messenger>(config: WebRtcSocketConfig, channels: MessageLoopChannels) {
-    M::message_loop(config, channels).await
+async fn message_loop<M: Messenger>(
+    id: Arc<Mutex<Option<PeerId>>>,
+    config: WebRtcSocketConfig,
+    channels: MessageLoopChannels,
+) {
+    M::message_loop(id, config, channels).await
 }

--- a/matchbox_socket/src/webrtc_socket/native.rs
+++ b/matchbox_socket/src/webrtc_socket/native.rs
@@ -20,7 +20,7 @@ use futures::{
 use futures_channel::mpsc::{UnboundedReceiver, UnboundedSender};
 use futures_timer::Delay;
 use futures_util::{lock::Mutex, select};
-use log::{debug, error, info, trace, warn};
+use log::{debug, error, trace, warn};
 use std::{collections::HashMap, pin::Pin, sync::Arc, time::Duration};
 use webrtc::{
     api::APIBuilder,
@@ -83,8 +83,12 @@ pub(crate) struct NativeMessenger;
 
 #[async_trait]
 impl Messenger for NativeMessenger {
-    async fn message_loop(config: WebRtcSocketConfig, channels: MessageLoopChannels) {
-        message_loop_impl(&config, channels)
+    async fn message_loop(
+        id: Arc<Mutex<Option<PeerId>>>,
+        config: WebRtcSocketConfig,
+        channels: MessageLoopChannels,
+    ) {
+        message_loop_impl(id, &config, channels)
             // web-rtc is tokio-based so we use compat here to make it work with other async
             // run-times
             .compat()
@@ -92,7 +96,11 @@ impl Messenger for NativeMessenger {
     }
 }
 
-async fn message_loop_impl(config: &WebRtcSocketConfig, channels: MessageLoopChannels) {
+async fn message_loop_impl(
+    id: Arc<Mutex<Option<PeerId>>>,
+    config: &WebRtcSocketConfig,
+    channels: MessageLoopChannels,
+) {
     let MessageLoopChannels {
         requests_sender,
         mut events_receiver,
@@ -132,7 +140,8 @@ async fn message_loop_impl(config: &WebRtcSocketConfig, channels: MessageLoopCha
                     debug!("{:?}", event);
                     match event {
                         PeerEvent::IdAssigned(peer_uuid) => {
-                            info!("Assigned UUID: {peer_uuid}");
+                            let mut id_mutex = id.lock().await;
+                            *id_mutex = Some(peer_uuid);
                         }
                         PeerEvent::NewPeer(peer_uuid) => {
                             let (signal_sender, signal_receiver) = futures_channel::mpsc::unbounded();

--- a/matchbox_socket/src/webrtc_socket/native.rs
+++ b/matchbox_socket/src/webrtc_socket/native.rs
@@ -140,7 +140,7 @@ async fn message_loop_impl(
                     debug!("{:?}", event);
                     match event {
                         PeerEvent::IdAssigned(peer_uuid) => {
-                            id_tx.send(peer_uuid.to_owned()).await.unwrap();
+                            id_tx.try_send(peer_uuid.to_owned()).unwrap();
                         }
                         PeerEvent::NewPeer(peer_uuid) => {
                             let (signal_sender, signal_receiver) = futures_channel::mpsc::unbounded();

--- a/matchbox_socket/src/webrtc_socket/wasm.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm.rs
@@ -13,11 +13,12 @@ use futures::{
 };
 use futures_channel::mpsc::{UnboundedReceiver, UnboundedSender};
 use futures_timer::Delay;
+use futures_util::lock::Mutex;
 use futures_util::select;
 use js_sys::{Function, Reflect};
-use log::{debug, error, info, warn};
+use log::{debug, error, warn};
 use serde::Serialize;
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use wasm_bindgen::{convert::FromWasmAbi, prelude::*, JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{
@@ -77,7 +78,11 @@ pub(crate) struct WasmMessenger;
 
 #[async_trait(?Send)]
 impl Messenger for WasmMessenger {
-    async fn message_loop(config: WebRtcSocketConfig, channels: MessageLoopChannels) {
+    async fn message_loop(
+        id: Arc<Mutex<Option<PeerId>>>,
+        config: WebRtcSocketConfig,
+        channels: MessageLoopChannels,
+    ) {
         let MessageLoopChannels {
             requests_sender,
             mut events_receiver,
@@ -123,7 +128,8 @@ impl Messenger for WasmMessenger {
 
                         match event {
                             PeerEvent::IdAssigned(peer_uuid) => {
-                                info!("Assigned UUID: {peer_uuid}");
+                                let mut id_mutex = id.lock().await;
+                                *id_mutex = Some(peer_uuid);
                             }
                             PeerEvent::NewPeer(peer_uuid) => {
                                 let (signal_sender, signal_receiver) = futures_channel::mpsc::unbounded();

--- a/matchbox_socket/src/webrtc_socket/wasm.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm.rs
@@ -127,7 +127,7 @@ impl Messenger for WasmMessenger {
 
                         match event {
                             PeerEvent::IdAssigned(peer_uuid) => {
-                                id_tx.send(peer_uuid.to_owned()).await.unwrap();
+                                id_tx.try_send(peer_uuid.to_owned()).unwrap();
                             }
                             PeerEvent::NewPeer(peer_uuid) => {
                                 let (signal_sender, signal_receiver) = futures_channel::mpsc::unbounded();


### PR DESCRIPTION
Thought `matchbox_server` should be the one to produce the `PeerId` then saw a comment with the same idea :laughing:
Currently don't make the `PeerId` super available in the client, but also don't yet have a need