### PR TITLE
Abstract message loop implementation

### DIFF
--- a/matchbox_socket/src/webrtc_socket/error.rs
+++ b/matchbox_socket/src/webrtc_socket/error.rs
@@ -28,7 +28,7 @@ pub enum SignallingError {
 
 /// An error that can occur with WebRTC messaging.
 #[derive(Debug, thiserror::Error)]
-pub enum MessagingError {
+pub(crate) enum MessagingError {
     // Native
     #[cfg(not(target_arch = "wasm32"))]
     #[error("failed to send message to peer")]

--- a/matchbox_socket/src/webrtc_socket/error.rs
+++ b/matchbox_socket/src/webrtc_socket/error.rs
@@ -27,18 +27,15 @@ pub enum SignallingError {
 }
 
 /// An error that can occur with WebRTC messaging.
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum MessagingError {
-    // Native
-    #[cfg(not(target_arch = "wasm32"))]
-    #[error("failed to send message to peer")]
-    SendError(#[from] futures_channel::mpsc::TrySendError<crate::Packet>),
+#[error("failed to send message to peer")]
+pub(crate) struct MessagingError(#[from] futures_channel::mpsc::TrySendError<crate::Packet>);
 
-    // WASM
-    #[cfg(target_arch = "wasm32")]
-    #[error("failed to send message to peer")]
-    SendError(#[from] JsError),
-}
+#[cfg(target_arch = "wasm32")]
+#[derive(Debug, thiserror::Error)]
+#[error("failed to send message to peer")]
+pub(crate) struct MessagingError(#[from] JsError);
 
 cfg_if! {
     if #[cfg(target_arch = "wasm32")] {

--- a/matchbox_socket/src/webrtc_socket/error.rs
+++ b/matchbox_socket/src/webrtc_socket/error.rs
@@ -24,3 +24,12 @@ pub enum SignallingError {
     #[error("socket failure communicating with signalling server")]
     Socket(#[from] ws_stream_wasm::WsErr),
 }
+
+/// An error that can occur with WebRTC messaging.
+
+#[derive(Debug, thiserror::Error)]
+pub enum MessagingError {
+    // Common
+    #[error("failed to send message to peer")]
+    SendError(Option<String>),
+}

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -89,11 +89,11 @@ async fn signalling_loop<S: Signaller>(
 /// The raw format of data being sent and received.
 pub type Packet = Box<[u8]>;
 
-trait DataChannel {
+trait PeerDataSender {
     fn send(&mut self, packet: Packet) -> Result<(), MessagingError>;
 }
 
-struct HandshakeResult<D: DataChannel, M> {
+struct HandshakeResult<D: PeerDataSender, M> {
     peer_id: PeerId,
     data_channels: Vec<D>,
     metadata: M,
@@ -102,7 +102,7 @@ struct HandshakeResult<D: DataChannel, M> {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 trait Messenger {
-    type DataChannel: DataChannel;
+    type DataChannel: PeerDataSender;
     type HandshakeMeta: Send;
 
     async fn offer_handshake(

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -3,18 +3,21 @@ mod messages;
 mod signal_peer;
 mod socket;
 
-use crate::{webrtc_socket::error::SignallingError, Error};
+use crate::{webrtc_socket::signal_peer::SignalPeer, Error};
 use async_trait::async_trait;
 use cfg_if::cfg_if;
-use futures::{Future, FutureExt, StreamExt};
-use futures_channel::mpsc::Sender;
+use futures::{stream::FuturesUnordered, Future, FutureExt, StreamExt};
+use futures_channel::mpsc::{Sender, UnboundedReceiver, UnboundedSender};
+use futures_timer::Delay;
 use futures_util::select;
 use log::{debug, warn};
 use matchbox_protocol::PeerId;
 use messages::*;
 pub(crate) use socket::MessageLoopChannels;
 pub use socket::{ChannelConfig, PeerState, RtcIceServerConfig, WebRtcSocket, WebRtcSocketConfig};
-use std::pin::Pin;
+use std::{collections::HashMap, pin::Pin, time::Duration};
+
+use self::error::{MessagingError, SignallingError};
 
 cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
@@ -33,9 +36,6 @@ cfg_if! {
         pub type MessageLoopFuture = Pin<Box<dyn Future<Output = Result<(), Error>> + Send>>;
     }
 }
-
-/// The raw format of data being sent and received.
-pub type Packet = Box<[u8]>;
 
 // TODO: Should be a WebRtcConfig field
 /// The duration, in milliseconds, to send "Keep Alive" requests
@@ -86,20 +86,137 @@ async fn signalling_loop<S: Signaller>(
     }
 }
 
+/// The raw format of data being sent and received.
+pub type Packet = Box<[u8]>;
+
+trait DataChannel {
+    fn send(&mut self, packet: Packet) -> Result<(), MessagingError>;
+}
+
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 trait Messenger {
-    async fn message_loop(
-        id_tx: Sender<PeerId>,
-        config: WebRtcSocketConfig,
-        channels: MessageLoopChannels,
-    );
+    type DataChannel: DataChannel;
+    type PeerLoopArgs: Send;
+
+    async fn handle_new_peer(
+        signal_peer: SignalPeer,
+        signal_rx: UnboundedReceiver<PeerSignal>,
+        peer_state_tx: UnboundedSender<(PeerId, PeerState)>,
+        messages_from_peers_tx: Vec<UnboundedSender<(PeerId, Packet)>>,
+        config: &WebRtcSocketConfig,
+    ) -> (PeerId, Vec<Self::DataChannel>, Self::PeerLoopArgs);
+
+    async fn handle_peer_signal(
+        signal_peer: SignalPeer,
+        from_peer_rx: UnboundedReceiver<PeerSignal>,
+        peer_state_tx: UnboundedSender<(PeerId, PeerState)>,
+        messages_from_peers_tx: Vec<UnboundedSender<(PeerId, Packet)>>,
+        config: &WebRtcSocketConfig,
+    ) -> (PeerId, Vec<Self::DataChannel>, Self::PeerLoopArgs);
+
+    async fn peer_loop(peer_uuid: PeerId, peer_loop_args: Self::PeerLoopArgs) -> PeerId;
 }
 
 async fn message_loop<M: Messenger>(
-    id_tx: Sender<PeerId>,
+    mut id_tx: Sender<PeerId>,
     config: WebRtcSocketConfig,
     channels: MessageLoopChannels,
 ) {
-    M::message_loop(id_tx, config, channels).await
+    let MessageLoopChannels {
+        requests_sender,
+        mut events_receiver,
+        mut peer_messages_out_rx,
+        messages_from_peers_tx,
+        peer_state_tx,
+    } = channels;
+
+    let mut handshakes = FuturesUnordered::new();
+    let mut peer_loops = FuturesUnordered::new();
+    let mut handshake_signals = HashMap::new();
+    let mut data_channels = HashMap::new();
+
+    let mut timeout = Delay::new(Duration::from_millis(KEEP_ALIVE_INTERVAL)).fuse();
+
+    loop {
+        let mut next_peer_messages_out = peer_messages_out_rx
+            .iter_mut()
+            .enumerate()
+            .map(|(channel, rx)| async move { (channel, rx.next().await) })
+            .collect::<FuturesUnordered<_>>();
+
+        let mut next_peer_message_out = next_peer_messages_out.next().fuse();
+
+        select! {
+            _  = &mut timeout => {
+                requests_sender.unbounded_send(PeerRequest::KeepAlive).expect("send failed");
+                timeout = Delay::new(Duration::from_millis(KEEP_ALIVE_INTERVAL)).fuse();
+            }
+
+            message = events_receiver.next().fuse() => {
+                if let Some(event) = message {
+                    debug!("{:?}", event);
+                    match event {
+                        PeerEvent::IdAssigned(peer_uuid) => {
+                            id_tx.try_send(peer_uuid.to_owned()).unwrap();
+                        },
+                        PeerEvent::NewPeer(peer_uuid) => {
+                            let (signal_tx, signal_rx) = futures_channel::mpsc::unbounded();
+                            handshake_signals.insert(peer_uuid.clone(), signal_tx);
+                            let signal_peer = SignalPeer::new(peer_uuid, requests_sender.clone());
+                            handshakes.push(M::handle_new_peer(signal_peer, signal_rx, peer_state_tx.clone(), messages_from_peers_tx.clone(), &config))
+                            // TODO: Finish implementing specializations of handle_new_peer
+                            // TODO: Figure out where / how to push to connected_peers
+                            // TOIO: Figure out why packets aren't sent
+                        },
+                        PeerEvent::PeerLeft(peer_uuid) => {peer_state_tx.unbounded_send((peer_uuid, PeerState::Disconnected)).expect("fail to report peer as disconnected");},
+                        PeerEvent::Signal { sender, data } => {
+                            handshake_signals.entry(sender.clone()).or_insert_with(|| {
+                                let (from_peer_tx, from_peer_rx) = futures_channel::mpsc::unbounded();
+                                let signal_peer = SignalPeer::new(sender.clone(), requests_sender.clone());
+                                handshakes.push(M::handle_peer_signal(signal_peer, from_peer_rx, peer_state_tx.clone(), messages_from_peers_tx.clone(), &config));
+                                // TODO: Implement specializations of handle_peer_signal
+                                from_peer_tx
+                            }).unbounded_send(data).expect("failed to forward signal to handshaker");
+                        },
+                    }
+                }
+            }
+
+            handshake_result = handshakes.select_next_some() => {
+                let (peer_uuid, new_data_channels, handshake_result) = handshake_result;
+                data_channels.insert(peer_uuid.clone(), new_data_channels);
+                peer_state_tx.unbounded_send((peer_uuid.clone(), PeerState::Connected)).expect("failed to report peer as connected");
+                peer_loops.push(M::peer_loop(peer_uuid, handshake_result));
+            }
+
+            peer_uuid = peer_loops.select_next_some() => {
+                debug!("Peer {peer_uuid} finished");
+                peer_state_tx.unbounded_send((peer_uuid, PeerState::Disconnected)).expect("failed to report peer as disconnected");
+            }
+
+            message = next_peer_message_out => {
+                match message {
+                    Some((channel_index, Some((peer, packet)))) => {
+                        let data_channel = data_channels
+                            .get_mut(&peer)
+                            .expect("couldn't find data channel for peer")
+                            .get_mut(channel_index).unwrap_or_else(|| panic!("couldn't find data channel with index {channel_index}"));
+                        data_channel.send(packet).unwrap();
+
+                    }
+                    Some((_, None)) | None => {
+                        // Receiver end of outgoing message channel closed,
+                        // which most likely means the socket was dropped.
+                        // There could probably be cleaner ways to handle this,
+                        // but for now, just exit cleanly.
+                        debug!("Outgoing message queue closed");
+                        break;
+                    }
+                }
+            }
+
+            complete => break
+        }
+    }
 }

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -165,9 +165,6 @@ async fn message_loop<M: Messenger>(
                             handshake_signals.insert(peer_uuid.clone(), signal_tx);
                             let signal_peer = SignalPeer::new(peer_uuid, requests_sender.clone());
                             handshakes.push(M::offer_handshake(signal_peer, signal_rx, peer_state_tx.clone(), messages_from_peers_tx.clone(), &config))
-                            // TODO: Finish implementing specializations of handle_new_peer
-                            // TODO: Figure out where / how to push to connected_peers
-                            // TOIO: Figure out why packets aren't sent
                         },
                         PeerEvent::PeerLeft(peer_uuid) => {peer_state_tx.unbounded_send((peer_uuid, PeerState::Disconnected)).expect("fail to report peer as disconnected");},
                         PeerEvent::Signal { sender, data } => {
@@ -175,7 +172,6 @@ async fn message_loop<M: Messenger>(
                                 let (from_peer_tx, from_peer_rx) = futures_channel::mpsc::unbounded();
                                 let signal_peer = SignalPeer::new(sender.clone(), requests_sender.clone());
                                 handshakes.push(M::accept_handshake(signal_peer, from_peer_rx, peer_state_tx.clone(), messages_from_peers_tx.clone(), &config));
-                                // TODO: Implement specializations of handle_peer_signal
                                 from_peer_tx
                             }).unbounded_send(data).expect("failed to forward signal to handshaker");
                         },

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -101,7 +101,7 @@ trait Messenger {
 
     async fn offer_handshake(
         signal_peer: SignalPeer,
-        signal_rx: UnboundedReceiver<PeerSignal>,
+        from_peer_rx: UnboundedReceiver<PeerSignal>,
         peer_state_tx: UnboundedSender<(PeerId, PeerState)>,
         messages_from_peers_tx: Vec<UnboundedSender<(PeerId, Packet)>>,
         config: &WebRtcSocketConfig,

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -97,7 +97,7 @@ trait DataChannel {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 trait Messenger {
     type DataChannel: DataChannel;
-    type PeerLoopArgs: Send;
+    type HandshakeMeta: Send;
 
     async fn offer_handshake(
         signal_peer: SignalPeer,
@@ -105,7 +105,7 @@ trait Messenger {
         peer_state_tx: UnboundedSender<(PeerId, PeerState)>,
         messages_from_peers_tx: Vec<UnboundedSender<(PeerId, Packet)>>,
         config: &WebRtcSocketConfig,
-    ) -> (PeerId, Vec<Self::DataChannel>, Self::PeerLoopArgs);
+    ) -> (PeerId, Vec<Self::DataChannel>, Self::HandshakeMeta);
 
     async fn accept_handshake(
         signal_peer: SignalPeer,
@@ -113,9 +113,9 @@ trait Messenger {
         peer_state_tx: UnboundedSender<(PeerId, PeerState)>,
         messages_from_peers_tx: Vec<UnboundedSender<(PeerId, Packet)>>,
         config: &WebRtcSocketConfig,
-    ) -> (PeerId, Vec<Self::DataChannel>, Self::PeerLoopArgs);
+    ) -> (PeerId, Vec<Self::DataChannel>, Self::HandshakeMeta);
 
-    async fn peer_loop(peer_uuid: PeerId, peer_loop_args: Self::PeerLoopArgs) -> PeerId;
+    async fn peer_loop(peer_uuid: PeerId, peer_loop_args: Self::HandshakeMeta) -> PeerId;
 }
 
 async fn message_loop<M: Messenger>(

--- a/matchbox_socket/src/webrtc_socket/native.rs
+++ b/matchbox_socket/src/webrtc_socket/native.rs
@@ -3,7 +3,7 @@ use crate::webrtc_socket::{
     error::SignallingError,
     messages::PeerSignal,
     signal_peer::SignalPeer,
-    socket::{create_data_channels_ready_fut, new_senders_and_receivers, PeerState},
+    socket::{create_data_channels_ready_fut, new_senders_and_receivers},
     ChannelConfig, Messenger, Packet, Signaller, WebRtcSocketConfig,
 };
 use async_compat::{Compat, CompatExt};
@@ -102,7 +102,6 @@ impl Messenger for NativeMessenger {
     async fn offer_handshake(
         signal_peer: SignalPeer,
         mut from_peer_rx: UnboundedReceiver<PeerSignal>,
-        _peer_state_tx: UnboundedSender<(PeerId, PeerState)>,
         messages_from_peers_tx: Vec<UnboundedSender<(PeerId, Packet)>>,
         config: &WebRtcSocketConfig,
     ) -> HandshakeResult<Self::DataChannel, Self::HandshakeMeta> {
@@ -180,7 +179,6 @@ impl Messenger for NativeMessenger {
     async fn accept_handshake(
         signal_peer: SignalPeer,
         mut from_peer_rx: UnboundedReceiver<PeerSignal>,
-        _peer_state_tx: UnboundedSender<(PeerId, PeerState)>,
         messages_from_peers_tx: Vec<UnboundedSender<(PeerId, Packet)>>,
         config: &WebRtcSocketConfig,
     ) -> HandshakeResult<Self::DataChannel, Self::HandshakeMeta> {

--- a/matchbox_socket/src/webrtc_socket/native.rs
+++ b/matchbox_socket/src/webrtc_socket/native.rs
@@ -516,13 +516,6 @@ async fn create_data_channel(
         }));
     }
 
-    channel.on_close(Box::new(move || {
-        // TODO: handle this somehow
-        debug!("Data channel closed");
-
-        Box::pin(async move {})
-    }));
-
     channel.on_error(Box::new(move |e| {
         // TODO: handle this somehow
         warn!("Data channel error {:?}", e);

--- a/matchbox_socket/src/webrtc_socket/native.rs
+++ b/matchbox_socket/src/webrtc_socket/native.rs
@@ -1,4 +1,4 @@
-use super::{error::MessagingError, DataChannel, HandshakeResult};
+use super::{error::MessagingError, HandshakeResult, PeerDataSender};
 use crate::webrtc_socket::{
     error::SignallingError,
     messages::PeerSignal,
@@ -83,7 +83,7 @@ impl Signaller for NativeSignaller {
 
 pub(crate) struct NativeMessenger;
 
-impl DataChannel for UnboundedSender<Packet> {
+impl PeerDataSender for UnboundedSender<Packet> {
     fn send(&mut self, packet: Packet) -> Result<(), super::error::MessagingError> {
         self.unbounded_send(packet).map_err(MessagingError::from)
     }

--- a/matchbox_socket/src/webrtc_socket/native.rs
+++ b/matchbox_socket/src/webrtc_socket/native.rs
@@ -92,7 +92,7 @@ impl DataChannel for UnboundedSender<Packet> {
 #[async_trait]
 impl Messenger for NativeMessenger {
     type DataChannel = UnboundedSender<Packet>;
-    type PeerLoopArgs = (
+    type HandshakeMeta = (
         Vec<UnboundedReceiver<Packet>>,
         (
             Vec<Arc<RTCDataChannel>>,
@@ -106,7 +106,7 @@ impl Messenger for NativeMessenger {
         peer_state_tx: UnboundedSender<(PeerId, PeerState)>,
         messages_from_peers_tx: Vec<UnboundedSender<(PeerId, Packet)>>,
         config: &WebRtcSocketConfig,
-    ) -> (PeerId, Vec<Self::DataChannel>, Self::PeerLoopArgs) {
+    ) -> (PeerId, Vec<Self::DataChannel>, Self::HandshakeMeta) {
         let (to_peer_message_tx, to_peer_message_rx) = new_senders_and_receivers(config);
 
         debug!("making offer");
@@ -178,7 +178,7 @@ impl Messenger for NativeMessenger {
         peer_state_tx: UnboundedSender<(PeerId, PeerState)>,
         messages_from_peers_tx: Vec<UnboundedSender<(PeerId, Packet)>>,
         config: &WebRtcSocketConfig,
-    ) -> (PeerId, Vec<Self::DataChannel>, Self::PeerLoopArgs) {
+    ) -> (PeerId, Vec<Self::DataChannel>, Self::HandshakeMeta) {
         let (to_peer_message_tx, to_peer_message_rx) = new_senders_and_receivers(config);
 
         debug!("handshake_accept");
@@ -234,7 +234,7 @@ impl Messenger for NativeMessenger {
         )
     }
 
-    async fn peer_loop(peer_uuid: PeerId, peer_loop_args: Self::PeerLoopArgs) -> PeerId {
+    async fn peer_loop(peer_uuid: PeerId, peer_loop_args: Self::HandshakeMeta) -> PeerId {
         let (mut to_peer_message_rx, (data_channels, mut trickle_fut)) = peer_loop_args;
 
         assert_eq!(

--- a/matchbox_socket/src/webrtc_socket/native.rs
+++ b/matchbox_socket/src/webrtc_socket/native.rs
@@ -85,8 +85,7 @@ pub(crate) struct NativeMessenger;
 
 impl DataChannel for UnboundedSender<Packet> {
     fn send(&mut self, packet: Packet) -> Result<(), super::error::MessagingError> {
-        self.unbounded_send(packet)
-            .map_err(|err| MessagingError::SendError(Some(err.to_string())))
+        self.unbounded_send(packet).map_err(MessagingError::from)
     }
 }
 

--- a/matchbox_socket/src/webrtc_socket/native.rs
+++ b/matchbox_socket/src/webrtc_socket/native.rs
@@ -6,7 +6,7 @@ use crate::webrtc_socket::{
     socket::{create_data_channels_ready_fut, new_senders_and_receivers},
     ChannelConfig, Messenger, Packet, Signaller, WebRtcSocketConfig,
 };
-use async_compat::{Compat, CompatExt};
+use async_compat::CompatExt;
 use async_trait::async_trait;
 use async_tungstenite::{
     async_std::{connect_async, ConnectStream},
@@ -288,7 +288,7 @@ async fn complete_handshake(
     connection: &Arc<RTCPeerConnection>,
     from_peer_rx: UnboundedReceiver<PeerSignal>,
     mut wait_for_channels: Pin<Box<Fuse<impl Future<Output = ()>>>>,
-) -> Pin<Box<Fuse<Compat<impl Future<Output = Result<(), webrtc::Error>>>>>> {
+) -> Pin<Box<Fuse<impl Future<Output = Result<(), webrtc::Error>>>>> {
     trickle.send_pending_candidates().await;
     let mut trickle_fut = Box::pin(
         CandidateTrickle::listen_for_remote_candidates(Arc::clone(connection), from_peer_rx)

--- a/matchbox_socket/src/webrtc_socket/wasm.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm.rs
@@ -10,7 +10,7 @@ use crate::webrtc_socket::{
     WebRtcSocketConfig,
 };
 use async_trait::async_trait;
-use futures::{future::Fuse as FuseFut, stream::Fuse as FuseStr, Future, SinkExt, StreamExt};
+use futures::{Future, SinkExt, StreamExt};
 use futures_channel::{
     mpsc::Receiver,
     mpsc::{UnboundedReceiver, UnboundedSender},
@@ -30,7 +30,7 @@ use web_sys::{
 use ws_stream_wasm::{WsMessage, WsMeta, WsStream};
 
 pub(crate) struct WasmSignaller {
-    websocket_stream: FuseStr<WsStream>,
+    websocket_stream: futures::stream::Fuse<WsStream>,
 }
 
 #[async_trait(?Send)]
@@ -294,7 +294,7 @@ async fn complete_handshake(
     signal_peer: SignalPeer,
     conn: RtcPeerConnection,
     received_candidates: Vec<PeerId>,
-    mut wait_for_channels: Pin<Box<FuseFut<impl Future<Output = ()>>>>,
+    mut wait_for_channels: Pin<Box<futures::future::Fuse<impl Future<Output = ()>>>>,
     mut from_peer_rx: UnboundedReceiver<PeerSignal>,
 ) {
     let onicecandidate: Box<dyn FnMut(RtcPeerConnectionIceEvent)> = Box::new(

--- a/matchbox_socket/src/webrtc_socket/wasm.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm.rs
@@ -498,7 +498,6 @@ fn create_data_channel(
         },
     );
 
-    let peer_id_1 = peer_id.clone();
     leaking_channel_event_handler(
         |f| channel.set_onmessage(f),
         move |event: MessageEvent| {
@@ -508,7 +507,7 @@ fn create_data_channel(
                 let body = uarray.to_vec();
 
                 incoming_tx
-                    .unbounded_send((peer_id_1.clone(), body.into_boxed_slice()))
+                    .unbounded_send((peer_id.clone(), body.into_boxed_slice()))
                     .unwrap();
             }
         },

--- a/matchbox_socket/src/webrtc_socket/wasm.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm.rs
@@ -82,7 +82,7 @@ pub(crate) struct WasmMessenger;
 #[async_trait(?Send)]
 impl Messenger for WasmMessenger {
     type DataChannel = RtcDataChannel;
-    type PeerLoopArgs = ();
+    type HandshakeMeta = ();
 
     async fn offer_handshake(
         signal_peer: SignalPeer,
@@ -90,7 +90,7 @@ impl Messenger for WasmMessenger {
         peer_state_tx: UnboundedSender<(PeerId, PeerState)>,
         messages_from_peers_tx: Vec<UnboundedSender<(PeerId, Packet)>>,
         config: &WebRtcSocketConfig,
-    ) -> (PeerId, Vec<Self::DataChannel>, Self::PeerLoopArgs) {
+    ) -> (PeerId, Vec<Self::DataChannel>, Self::HandshakeMeta) {
         debug!("making offer");
 
         let conn = create_rtc_peer_connection(config);
@@ -177,7 +177,7 @@ impl Messenger for WasmMessenger {
         peer_state_tx: UnboundedSender<(PeerId, PeerState)>,
         messages_from_peers_tx: Vec<UnboundedSender<(PeerId, Packet)>>,
         config: &WebRtcSocketConfig,
-    ) -> (PeerId, Vec<Self::DataChannel>, Self::PeerLoopArgs) {
+    ) -> (PeerId, Vec<Self::DataChannel>, Self::HandshakeMeta) {
         debug!("handshake_accept");
 
         let conn = create_rtc_peer_connection(config);
@@ -267,7 +267,7 @@ impl Messenger for WasmMessenger {
         (signal_peer.id, data_channels, ())
     }
 
-    async fn peer_loop(peer_uuid: PeerId, _handshake_result: Self::PeerLoopArgs) -> PeerId {
+    async fn peer_loop(peer_uuid: PeerId, _handshake_result: Self::HandshakeMeta) -> PeerId {
         peer_uuid
     }
 }

--- a/matchbox_socket/src/webrtc_socket/wasm.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::webrtc_socket::{
     error::SignallingError, messages::PeerSignal, signal_peer::SignalPeer,
-    socket::create_data_channels_ready_fut, ChannelConfig, Messenger, Packet, PeerState, Signaller,
+    socket::create_data_channels_ready_fut, ChannelConfig, Messenger, Packet, Signaller,
     WebRtcSocketConfig,
 };
 use async_trait::async_trait;
@@ -93,7 +93,6 @@ impl Messenger for WasmMessenger {
     async fn offer_handshake(
         signal_peer: SignalPeer,
         mut from_peer_rx: UnboundedReceiver<PeerSignal>,
-        _peer_state_tx: UnboundedSender<(PeerId, PeerState)>,
         messages_from_peers_tx: Vec<UnboundedSender<(PeerId, Packet)>>,
         config: &WebRtcSocketConfig,
     ) -> HandshakeResult<Self::DataChannel, Self::HandshakeMeta> {
@@ -185,7 +184,6 @@ impl Messenger for WasmMessenger {
     async fn accept_handshake(
         signal_peer: SignalPeer,
         mut from_peer_rx: UnboundedReceiver<PeerSignal>,
-        _peer_state_tx: UnboundedSender<(PeerId, PeerState)>,
         messages_from_peers_tx: Vec<UnboundedSender<(PeerId, Packet)>>,
         config: &WebRtcSocketConfig,
     ) -> HandshakeResult<Self::DataChannel, Self::HandshakeMeta> {

--- a/matchbox_socket/src/webrtc_socket/wasm.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm.rs
@@ -2,7 +2,7 @@ use std::pin::Pin;
 
 use super::{
     error::{JsErrorExt, MessagingError},
-    DataChannel, HandshakeResult,
+    HandshakeResult, PeerDataSender,
 };
 use crate::webrtc_socket::{
     error::SignallingError, messages::PeerSignal, signal_peer::SignalPeer,
@@ -72,7 +72,7 @@ impl Signaller for WasmSignaller {
     }
 }
 
-impl DataChannel for RtcDataChannel {
+impl PeerDataSender for RtcDataChannel {
     fn send(&mut self, packet: Packet) -> Result<(), MessagingError> {
         self.send_with_u8_array(&packet)
             .efix()


### PR DESCRIPTION
Had a go at abstracting the `message_loop` implementation via a series of `Messenger` trait functions