### PR TITLE
Remove `uuid` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3037,7 +3037,6 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "thiserror",
- "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -4889,7 +4888,6 @@ checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom 0.2.8",
  "serde",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/matchbox_socket/Cargo.toml
+++ b/matchbox_socket/Cargo.toml
@@ -22,7 +22,6 @@ futures-util = { version = "0.3", default-features = false, features = [
 ] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
-uuid = { version = "1.0", default-features = false, features = ["v4"] }
 log = { version = "0.4", default-features = false }
 thiserror = "1.0"
 cfg-if = "1.0"
@@ -37,7 +36,6 @@ ws_stream_wasm = { version = "0.7", default-features = false }
 wasm-bindgen-futures = { version = "0.4", default-features = false }
 wasm-bindgen = { version = "0.2", features = [ "serde-serialize" ], default-features = false }
 futures-timer = { version = "3.0", default-features = false, features = ["wasm-bindgen"] }
-uuid = { version = "1.0", default-features = false, features = ["v4", "js"] }
 js-sys = { version = "0.3", default-features = false }
 web-sys = { version = "0.3.22", default-features = false, features = [
     "MessageEvent",


### PR DESCRIPTION
After #111 , we don't actually need `uuid` in the socket crate.