### PR TITLE
Improve logging and code clarity

### DIFF
--- a/matchbox_socket/src/webrtc_socket/native.rs
+++ b/matchbox_socket/src/webrtc_socket/native.rs
@@ -464,7 +464,7 @@ async fn create_rtc_peer_connection(
 
 async fn create_data_channels(
     connection: &RTCPeerConnection,
-    mut data_channel_ready_txs: Vec<futures_channel::mpsc::Sender<u8>>,
+    mut data_channel_ready_txs: Vec<futures_channel::mpsc::Sender<()>>,
     peer_id: PeerId,
     peer_disconnected_tx: Sender<()>,
     from_peer_message_tx: Vec<UnboundedSender<(PeerId, Packet)>>,
@@ -491,7 +491,7 @@ async fn create_data_channels(
 
 async fn create_data_channel(
     connection: &RTCPeerConnection,
-    mut channel_ready: futures_channel::mpsc::Sender<u8>,
+    mut channel_ready: futures_channel::mpsc::Sender<()>,
     peer_id: PeerId,
     mut peer_disconnected_tx: Sender<()>,
     from_peer_message_tx: UnboundedSender<(PeerId, Packet)>,
@@ -513,7 +513,7 @@ async fn create_data_channel(
     channel.on_open(Box::new(move || {
         debug!("Data channel ready");
         Box::pin(async move {
-            channel_ready.try_send(1).unwrap();
+            channel_ready.try_send(()).unwrap();
         })
     }));
 

--- a/matchbox_socket/src/webrtc_socket/native.rs
+++ b/matchbox_socket/src/webrtc_socket/native.rs
@@ -199,10 +199,12 @@ impl Messenger for NativeMessenger {
                 .await
                 .unwrap();
 
-        let (channel_ready_tx, wait_for_channels) = create_data_channels_ready_fut(config);
+        let (data_channel_ready_txs, data_channels_ready_fut) =
+            create_data_channels_ready_fut(config);
+
         let data_channels = create_data_channels(
             &connection,
-            channel_ready_tx,
+            data_channel_ready_txs,
             signal_peer.id.clone(),
             peer_disconnected_tx.clone(),
             messages_from_peers_tx,
@@ -235,8 +237,13 @@ impl Messenger for NativeMessenger {
             .await
             .unwrap();
 
-        let trickle_fut =
-            complete_handshake(trickle, &connection, peer_signal_rx, wait_for_channels).await;
+        let trickle_fut = complete_handshake(
+            trickle,
+            &connection,
+            peer_signal_rx,
+            data_channels_ready_fut,
+        )
+        .await;
 
         HandshakeResult {
             peer_id: signal_peer.id,

--- a/matchbox_socket/src/webrtc_socket/native.rs
+++ b/matchbox_socket/src/webrtc_socket/native.rs
@@ -523,13 +523,13 @@ async fn create_data_channel(
 
     channel.on_error(Box::new(move |e| {
         // TODO: handle this somehow
-        warn!("Data channel error {:?}", e);
+        warn!("Data channel error {e:?}");
         Box::pin(async move {})
     }));
 
     channel.on_message(Box::new(move |message| {
         let packet = (*message.data).into();
-        debug!("rx {:?}", packet);
+        trace!("data channel message received: {packet:?}");
         from_peer_message_tx
             .unbounded_send((peer_id.clone(), packet))
             .unwrap();

--- a/matchbox_socket/src/webrtc_socket/native.rs
+++ b/matchbox_socket/src/webrtc_socket/native.rs
@@ -537,7 +537,7 @@ async fn create_data_channel(
 
     channel.on_error(Box::new(move |e| {
         // TODO: handle this somehow
-        warn!("Data channel error {e:?}");
+        warn!("data channel error {e:?}");
         Box::pin(async move {})
     }));
 

--- a/matchbox_socket/src/webrtc_socket/native.rs
+++ b/matchbox_socket/src/webrtc_socket/native.rs
@@ -272,7 +272,7 @@ impl Messenger for NativeMessenger {
             .zip(to_peer_message_rx.iter_mut())
             .map(|(data_channel, rx)| async move {
                 while let Some(message) = rx.next().await {
-                    trace!("sending packet {:?}", message);
+                    trace!("sending packet {message:?}");
                     let message = message.clone();
                     let message = Bytes::from(message);
                     if let Err(e) = data_channel.send(&message).await {

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -341,7 +341,7 @@ pub(crate) fn new_senders_and_receivers<T>(
 pub(crate) fn create_data_channels_ready_fut(
     config: &WebRtcSocketConfig,
 ) -> (
-    Vec<futures_channel::mpsc::Sender<u8>>,
+    Vec<futures_channel::mpsc::Sender<()>>,
     Pin<Box<Fuse<impl Future<Output = ()>>>>,
 ) {
     let (senders, receivers) = (0..config.channels.len())
@@ -351,7 +351,7 @@ pub(crate) fn create_data_channels_ready_fut(
     (senders, Box::pin(wait_for_ready(receivers).fuse()))
 }
 
-async fn wait_for_ready(channel_ready_rx: Vec<futures_channel::mpsc::Receiver<u8>>) {
+async fn wait_for_ready(channel_ready_rx: Vec<futures_channel::mpsc::Receiver<()>>) {
     for mut receiver in channel_ready_rx {
         if receiver.next().await.is_none() {
             panic!("Sender closed before channel was ready");

--- a/matchbox_socket/src/webrtc_socket/wasm.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm.rs
@@ -222,7 +222,7 @@ impl Messenger for WasmMessenger {
                     break o;
                 }
                 PeerSignal::IceCandidate(candidate) => {
-                    debug!("got an IceCandidate signal: {candidate:?}");
+                    debug!("received IceCandidate signal: {candidate:?}");
                     received_candidates.push(candidate);
                 }
                 _ => {
@@ -522,7 +522,7 @@ fn create_data_channel(
     leaking_channel_event_handler(
         |f| channel.set_onerror(f),
         move |event: Event| {
-            error!("Error in data channel: {event:?}");
+            error!("error in data channel: {event:?}");
         },
     );
 

--- a/matchbox_socket/src/webrtc_socket/wasm.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm.rs
@@ -449,7 +449,7 @@ fn create_data_channels(
     mut incoming_tx: Vec<futures_channel::mpsc::UnboundedSender<(PeerId, Packet)>>,
     peer_id: PeerId,
     peer_disconnected_tx: futures_channel::mpsc::Sender<()>,
-    mut channel_ready: Vec<futures_channel::mpsc::Sender<u8>>,
+    mut channel_ready: Vec<futures_channel::mpsc::Sender<()>>,
     channel_config: &[ChannelConfig],
 ) -> Vec<RtcDataChannel> {
     channel_config
@@ -474,7 +474,7 @@ fn create_data_channel(
     incoming_tx: futures_channel::mpsc::UnboundedSender<(PeerId, Packet)>,
     peer_id: PeerId,
     peer_disconnected_tx: futures_channel::mpsc::Sender<()>,
-    mut channel_open: futures_channel::mpsc::Sender<u8>,
+    mut channel_open: futures_channel::mpsc::Sender<()>,
     channel_config: &ChannelConfig,
     channel_id: usize,
 ) -> RtcDataChannel {
@@ -493,7 +493,7 @@ fn create_data_channel(
         move |_: JsValue| {
             debug!("data channel open: {channel_id}");
             channel_open
-                .try_send(1)
+                .try_send(())
                 .expect("failed to notify about open connection");
         },
     );


### PR DESCRIPTION
Some relatively minor and uncontroversial improvements to code quality and logging.

- Uses the new `"info!("format string: {variable}");` form for logging
- `data channel` instead of `channel` in log messages and variables to be more clear
- Renamed some variables that lacked plural form
- Send `()` instead of `u8` when we don't care about payload
- Be less hyperbolic in log messages