### PR TITLE
docs: Link to example folders, not READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ The Matchbox project contains both:
 
 ## Examples
 
-- [simple](examples/simple/README.md): A simple communication loop using matchbox_socket
-- [bevy_ggrs](examples/bevy_ggrs/README.md): An example browser game, using `bevy` and `bevy_ggrs`
+- [simple](examples/simple): A simple communication loop using matchbox_socket
+- [bevy_ggrs](examples/bevy_ggrs): An example browser game, using `bevy` and `bevy_ggrs`
   - Live 2-player demo: <https://helsing.studio/box_game/>
   - Live 4-player demo: <https://helsing.studio/box_game/?players=4>
 


### PR DESCRIPTION
Makes it easier to find the actual code, as you go directly to a view where you see both the example source files and its readme at the same time.

Maybe helps #148 a tiny bit? (Should be easy to find the documentation you're looking for)