### PR TITLE
Use builder pattern to construct WebRtcSocket

### DIFF
--- a/examples/bevy_ggrs/src/main.rs
+++ b/examples/bevy_ggrs/src/main.rs
@@ -1,7 +1,7 @@
 use bevy::{log::LogPlugin, prelude::*, tasks::IoTaskPool};
 use bevy_ggrs::{GGRSPlugin, Session};
 use ggrs::SessionBuilder;
-use matchbox_socket::{PeerState, WebRtcSocket};
+use matchbox_socket::{PeerState, WebRtcSocket, WebRtcSocketBuilder};
 
 mod args;
 mod box_game;
@@ -91,7 +91,9 @@ fn start_matchbox_socket(mut commands: Commands, args: Res<Args>) {
 
     let room_url = format!("{}/{}", &args.matchbox, room_id);
     info!("connecting to matchbox server: {:?}", room_url);
-    let (socket, message_loop) = WebRtcSocket::new_unreliable(room_url);
+    let (socket, message_loop) = WebRtcSocketBuilder::new(room_url, Some(3))
+        .add_unreliable_channel()
+        .build();
 
     // The message loop needs to be awaited, or nothing will happen.
     // We do this here using bevy's task system.

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -1,7 +1,7 @@
 use futures::{select, FutureExt};
 use futures_timer::Delay;
 use log::info;
-use matchbox_socket::{PeerState, WebRtcSocket};
+use matchbox_socket::{PeerState, WebRtcSocketBuilder};
 use std::time::Duration;
 
 #[cfg(target_arch = "wasm32")]
@@ -31,7 +31,9 @@ async fn main() {
 
 async fn async_main() {
     info!("Connecting to matchbox");
-    let (mut socket, loop_fut) = WebRtcSocket::new_unreliable("ws://localhost:3536/");
+    let (mut socket, loop_fut) = WebRtcSocketBuilder::new("ws://localhost:3536/", Some(3))
+        .add_unreliable_channel()
+        .build();
 
     let loop_fut = loop_fut.fuse();
     futures::pin_mut!(loop_fut);

--- a/matchbox_socket/src/lib.rs
+++ b/matchbox_socket/src/lib.rs
@@ -11,5 +11,5 @@ pub use error::Error;
 pub use matchbox_protocol::PeerId;
 pub use webrtc_socket::{
     ChannelConfig, MessageLoopFuture, Packet, PeerState, RtcIceServerConfig, WebRtcSocket,
-    WebRtcSocketConfig,
+    WebRtcSocketBuilder,
 };

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -14,7 +14,7 @@ use log::{debug, warn};
 use matchbox_protocol::PeerId;
 use messages::*;
 pub(crate) use socket::MessageLoopChannels;
-pub use socket::{ChannelConfig, PeerState, RtcIceServerConfig, WebRtcSocket, WebRtcSocketConfig};
+pub use socket::{ChannelConfig, PeerState, RtcIceServerConfig, WebRtcSocket, WebRtcSocketBuilder};
 use std::{collections::HashMap, pin::Pin, time::Duration};
 
 use self::error::{MessagingError, SignallingError};
@@ -107,16 +107,18 @@ trait Messenger {
 
     async fn offer_handshake(
         signal_peer: SignalPeer,
-        peer_signal_rx: UnboundedReceiver<PeerSignal>,
+        mut peer_signal_rx: UnboundedReceiver<PeerSignal>,
         messages_from_peers_tx: Vec<UnboundedSender<(PeerId, Packet)>>,
-        config: &WebRtcSocketConfig,
+        ice_server_config: &RtcIceServerConfig,
+        channel_configs: &Vec<ChannelConfig>,
     ) -> HandshakeResult<Self::DataChannel, Self::HandshakeMeta>;
 
     async fn accept_handshake(
         signal_peer: SignalPeer,
         peer_signal_rx: UnboundedReceiver<PeerSignal>,
         messages_from_peers_tx: Vec<UnboundedSender<(PeerId, Packet)>>,
-        config: &WebRtcSocketConfig,
+        ice_server_config: &RtcIceServerConfig,
+        channel_configs: &Vec<ChannelConfig>,
     ) -> HandshakeResult<Self::DataChannel, Self::HandshakeMeta>;
 
     async fn peer_loop(peer_uuid: PeerId, handshake_meta: Self::HandshakeMeta) -> PeerId;
@@ -124,7 +126,7 @@ trait Messenger {
 
 async fn message_loop<M: Messenger>(
     id_tx: crossbeam_channel::Sender<PeerId>,
-    config: WebRtcSocketConfig,
+    config: WebRtcSocketBuilder,
     channels: MessageLoopChannels,
 ) {
     let MessageLoopChannels {
@@ -168,14 +170,14 @@ async fn message_loop<M: Messenger>(
                             let (signal_tx, signal_rx) = futures_channel::mpsc::unbounded();
                             handshake_signals.insert(peer_uuid, signal_tx);
                             let signal_peer = SignalPeer::new(peer_uuid, requests_sender.clone());
-                            handshakes.push(M::offer_handshake(signal_peer, signal_rx, messages_from_peers_tx.clone(), &config))
+                            handshakes.push(M::offer_handshake(signal_peer, signal_rx, messages_from_peers_tx.clone(), &config.ice_server, &config.channels))
                         },
                         PeerEvent::PeerLeft(peer_uuid) => {peer_state_tx.unbounded_send((peer_uuid, PeerState::Disconnected)).expect("fail to report peer as disconnected");},
                         PeerEvent::Signal { sender, data } => {
                             handshake_signals.entry(sender).or_insert_with(|| {
                                 let (from_peer_tx, peer_signal_rx) = futures_channel::mpsc::unbounded();
                                 let signal_peer = SignalPeer::new(sender, requests_sender.clone());
-                                handshakes.push(M::accept_handshake(signal_peer, peer_signal_rx, messages_from_peers_tx.clone(), &config));
+                                handshakes.push(M::accept_handshake(signal_peer, peer_signal_rx, messages_from_peers_tx.clone(), &config.ice_server, &config.channels));
                                 from_peer_tx
                             }).unbounded_send(data).expect("failed to forward signal to handshaker");
                         },

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -76,7 +76,7 @@ impl Default for RtcIceServerConfig {
 ///
 /// See [`WebRtcSocket::new_with_config`]
 #[derive(Debug, Clone)]
-pub struct WebRtcSocketConfig {
+pub struct WebRtcSocketBuilder {
     /// The url for the room to connect to
     ///
     /// This is a websocket url, starting with `ws://` or `wss://` followed by
@@ -88,13 +88,90 @@ pub struct WebRtcSocketConfig {
     /// or: `wss://matchbox.example.com/your_game?next=2`
     ///
     /// The last form will pair player in the order they connect.
-    pub room_url: String,
+    pub(crate) room_url: String,
     /// Configuration for the (single) ICE server
-    pub ice_server: RtcIceServerConfig,
+    pub(crate) ice_server: RtcIceServerConfig,
     /// Configuration for one or multiple reliable or unreliable data channels
-    pub channels: Vec<ChannelConfig>,
+    pub(crate) channels: Vec<ChannelConfig>,
     /// The amount of attempts to initiate connection
-    pub attempts: Option<u16>,
+    pub(crate) attempts: Option<u16>,
+}
+
+impl WebRtcSocketBuilder {
+    /// Creates a new builder for a connection to a given room with a given number of
+    /// re-connection attempts.
+    ///
+    /// You must add at least one channel with [`WebRtcSocketBuilder::add_channel`],
+    /// [`WebRtcSocketBuilder::add_reliable_channel`], or
+    /// [`WebRtcSocketBuilder::add_unreliable_channel`] before you can build the
+    /// [`WebRtcSocket`]
+    pub fn new(room_url: impl ToString, attempts: Option<u16>) -> Self {
+        Self {
+            room_url: room_url.to_string(),
+            ice_server: RtcIceServerConfig::default(),
+            channels: Vec::default(),
+            attempts,
+        }
+    }
+
+    /// Adds a new channel to the [`WebRtcSocket`] configuration according to a [`ChannelConfig`].
+    pub fn add_channel(mut self, config: ChannelConfig) -> Self {
+        self.channels.push(config);
+        self
+    }
+
+    /// Adds a new reliable channel to the [`WebRtcSocket`].
+    ///
+    /// Messages sent via a reliable channel are guaranteed to arrive in order and will be resent
+    /// until they arrive
+    pub fn add_reliable_channel(mut self) -> Self {
+        self.channels.push(ChannelConfig::reliable());
+        self
+    }
+
+    /// Adds a new unreliable channel to the [`WebRtcSocket`].
+    ///
+    /// Messages sent via an unreliable channel may arrive in any order or not at all, but arrive as
+    /// quickly as possible
+    pub fn add_unreliable_channel(mut self) -> Self {
+        self.channels.push(ChannelConfig::unreliable());
+        self
+    }
+
+    /// Creates a [`WebRtcSocket`] and the corresponding [`MessageLoopFuture`] according to the configuration supplied.
+    ///
+    /// The returned [`MessageLoopFuture`] should be awaited in order for messages to be sent and received.
+    pub fn build(self) -> (WebRtcSocket, MessageLoopFuture) {
+        if self.channels.is_empty() {
+            panic!("You need to configure at least one channel in WebRtcSocketConfig");
+        }
+
+        let (messages_from_peers_tx, messages_from_peers) =
+            new_senders_and_receivers(&self.channels);
+        let (peer_state_tx, peer_state_rx) = futures_channel::mpsc::unbounded();
+        let (peer_messages_out_tx, peer_messages_out_rx) =
+            new_senders_and_receivers(&self.channels);
+
+        let (id_tx, id_rx) = crossbeam_channel::bounded(1);
+
+        (
+            WebRtcSocket {
+                id: Default::default(),
+                id_rx,
+                messages_from_peers,
+                peer_messages_out: peer_messages_out_tx,
+                peer_state_rx,
+                peers: Default::default(),
+            },
+            Box::pin(run_socket(
+                id_tx,
+                self,
+                peer_messages_out_rx,
+                peer_state_tx,
+                messages_from_peers_tx,
+            )),
+        )
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -130,70 +207,6 @@ pub struct WebRtcSocket {
 }
 
 impl WebRtcSocket {
-    /// Create a new connection to the given room with a single unreliable data channel
-    ///
-    /// See [`WebRtcSocketConfig::room_url`] for details on the room url.
-    ///
-    /// The returned future should be awaited in order for messages to be sent and received.
-    #[must_use]
-    pub fn new_unreliable(room_url: impl Into<String>) -> (Self, MessageLoopFuture) {
-        WebRtcSocket::new_with_config(WebRtcSocketConfig {
-            room_url: room_url.into(),
-            ice_server: RtcIceServerConfig::default(),
-            channels: vec![ChannelConfig::unreliable()],
-            attempts: Some(3),
-        })
-    }
-
-    /// Create a new connection to the given room with a single reliable data channel
-    ///
-    /// See [`WebRtcSocketConfig::room_url`] for details on the room url.
-    ///
-    /// The returned future should be awaited in order for messages to be sent and received.
-    #[must_use]
-    pub fn new_reliable(room_url: impl Into<String>) -> (Self, MessageLoopFuture) {
-        WebRtcSocket::new_with_config(WebRtcSocketConfig {
-            room_url: room_url.into(),
-            ice_server: RtcIceServerConfig::default(),
-            channels: vec![ChannelConfig::reliable()],
-            attempts: Some(3),
-        })
-    }
-
-    /// Create a new connection with the given [`WebRtcSocketConfig`]
-    ///
-    /// The returned future should be awaited in order for messages to be sent and received.
-    #[must_use]
-    pub fn new_with_config(config: WebRtcSocketConfig) -> (Self, MessageLoopFuture) {
-        if config.channels.is_empty() {
-            panic!("You need to configure at least one channel in WebRtcSocketConfig");
-        }
-
-        let (messages_from_peers_tx, messages_from_peers) = new_senders_and_receivers(&config);
-        let (peer_state_tx, peer_state_rx) = futures_channel::mpsc::unbounded();
-        let (peer_messages_out_tx, peer_messages_out_rx) = new_senders_and_receivers(&config);
-
-        let (id_tx, id_rx) = crossbeam_channel::bounded(1);
-
-        (
-            Self {
-                id: Default::default(),
-                id_rx,
-                messages_from_peers,
-                peer_messages_out: peer_messages_out_tx,
-                peer_state_rx,
-                peers: Default::default(),
-            },
-            Box::pin(run_socket(
-                id_tx,
-                config,
-                peer_messages_out_rx,
-                peer_state_tx,
-                messages_from_peers_tx,
-            )),
-        )
-    }
-
     /// Handle peers connecting or disconnecting
     ///
     /// Update the set of peers used by [`connected_peers`],
@@ -330,20 +343,20 @@ impl WebRtcSocket {
 }
 
 pub(crate) fn new_senders_and_receivers<T>(
-    config: &WebRtcSocketConfig,
+    channel_configs: &Vec<ChannelConfig>,
 ) -> (Vec<UnboundedSender<T>>, Vec<UnboundedReceiver<T>>) {
-    (0..config.channels.len())
+    (0..channel_configs.len())
         .map(|_| futures_channel::mpsc::unbounded())
         .unzip()
 }
 
 pub(crate) fn create_data_channels_ready_fut(
-    config: &WebRtcSocketConfig,
+    channel_configs: &Vec<ChannelConfig>,
 ) -> (
     Vec<futures_channel::mpsc::Sender<()>>,
     Pin<Box<Fuse<impl Future<Output = ()>>>>,
 ) {
-    let (senders, receivers) = (0..config.channels.len())
+    let (senders, receivers) = (0..channel_configs.len())
         .map(|_| futures_channel::mpsc::channel(1))
         .unzip();
 
@@ -369,7 +382,7 @@ pub struct MessageLoopChannels {
 
 async fn run_socket(
     id_tx: crossbeam_channel::Sender<PeerId>,
-    config: WebRtcSocketConfig,
+    config: WebRtcSocketBuilder,
     peer_messages_out_rx: Vec<futures_channel::mpsc::UnboundedReceiver<(PeerId, Packet)>>,
     peer_state_tx: futures_channel::mpsc::UnboundedSender<(PeerId, PeerState)>,
     messages_from_peers_tx: Vec<futures_channel::mpsc::UnboundedSender<(PeerId, Packet)>>,
@@ -423,15 +436,14 @@ async fn run_socket(
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        webrtc_socket::error::SignallingError, ChannelConfig, Error, RtcIceServerConfig,
-        WebRtcSocket, WebRtcSocketConfig,
-    };
+    use crate::{webrtc_socket::error::SignallingError, Error, WebRtcSocketBuilder};
 
     #[futures_test::test]
     async fn unreachable_server() {
         // .invalid is a reserved tld for testing and documentation
-        let (_socket, fut) = WebRtcSocket::new_reliable("wss://example.invalid");
+        let (_socket, fut) = WebRtcSocketBuilder::new("wss://example.invalid", Some(3))
+            .add_reliable_channel()
+            .build();
 
         let result = fut.await;
         assert!(result.is_err());
@@ -440,12 +452,9 @@ mod test {
 
     #[futures_test::test]
     async fn test_signalling_attempts() {
-        let (_socket, loop_fut) = WebRtcSocket::new_with_config(WebRtcSocketConfig {
-            room_url: "wss://example.invalid/".to_string(),
-            attempts: Some(3),
-            ice_server: RtcIceServerConfig::default(),
-            channels: vec![ChannelConfig::unreliable()],
-        });
+        let (_socket, loop_fut) = WebRtcSocketBuilder::new("wss://example.invalid/", Some(3))
+            .add_reliable_channel()
+            .build();
 
         let result = loop_fut.await;
         assert!(result.is_err());


### PR DESCRIPTION
Had a go at creating a builder for the `WebRtcSocket` to replace `WebRtcSocketConfig`, this should make things a touch easier when it comes to constructing sockets with numerous channels.