### PR TITLE
Remove `UnknownPeerId` error

### DIFF
--- a/examples/bevy_ggrs/src/main.rs
+++ b/examples/bevy_ggrs/src/main.rs
@@ -181,7 +181,7 @@ fn lobby_system(
     let socket = socket.0.take().unwrap();
 
     // extract final player list
-    let players = socket.players().unwrap();
+    let players = socket.players();
 
     let max_prediction = 12;
 

--- a/matchbox_protocol/src/lib.rs
+++ b/matchbox_protocol/src/lib.rs
@@ -24,7 +24,10 @@ pub enum PeerEvent<S> {
     IdAssigned(PeerId),
     NewPeer(PeerId),
     PeerLeft(PeerId),
-    Signal { sender: PeerId, data: S },
+    Signal {
+        sender: PeerId,
+        data: S,
+    },
 }
 
 cfg_if! {

--- a/matchbox_protocol/src/lib.rs
+++ b/matchbox_protocol/src/lib.rs
@@ -19,6 +19,8 @@ pub enum PeerRequest<S> {
 /// Events go from signalling server to peer
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum PeerEvent<S> {
+    /// Sent by the server to the connecting peer, immediately after connection
+    /// before any other events
     IdAssigned(PeerId),
     NewPeer(PeerId),
     PeerLeft(PeerId),


### PR DESCRIPTION
I found out we can actually return a valid player even if we don't have an id, since there shouldn't be any other peers at that point ,we don't need the sort, and consequently not the id.