### PR TITLE
Provide abstraction for a channel

### DIFF
--- a/examples/bevy_ggrs/src/main.rs
+++ b/examples/bevy_ggrs/src/main.rs
@@ -20,8 +20,8 @@ enum AppState {
 
 const SKY_COLOR: Color = Color::rgb(0.69, 0.69, 0.69);
 
-#[derive(Default, Resource)]
-struct SocketResource(Option<WebRtcSocket>);
+#[derive(Debug, Resource, Deref, DerefMut)]
+struct SocketResource(WebRtcSocket);
 
 fn main() {
     // read query string or command line arguments
@@ -98,7 +98,7 @@ fn start_matchbox_socket(mut commands: Commands, args: Res<Args>) {
     let task_pool = IoTaskPool::get();
     task_pool.spawn(message_loop).detach();
 
-    commands.insert_resource(SocketResource(Some(socket)));
+    commands.insert_resource(SocketResource(socket));
 }
 
 // Marker components for UI
@@ -160,7 +160,7 @@ fn lobby_system(
     mut query: Query<&mut Text, With<LobbyText>>,
 ) {
     // regularly call update_peers to update the list of connected peers
-    for (peer, new_state) in socket.0.as_mut().unwrap().update_peers() {
+    for (peer, new_state) in socket.update_peers() {
         // you can also handle the specific dis(connections) as they occur:
         match new_state {
             PeerState::Connected => info!("peer {peer:?} connected"),
@@ -168,7 +168,7 @@ fn lobby_system(
         }
     }
 
-    let connected_peers = socket.0.as_ref().unwrap().connected_peers().count();
+    let connected_peers = socket.connected_peers().count();
     let remaining = args.players - (connected_peers + 1);
     query.single_mut().sections[0].value = format!("Waiting for {remaining} more player(s)",);
     if remaining > 0 {
@@ -178,7 +178,7 @@ fn lobby_system(
     info!("All peers have joined, going in-game");
 
     // extract final player list
-    let players = socket.0.as_mut().unwrap().players();
+    let players = socket.players();
 
     let max_prediction = 12;
 
@@ -197,7 +197,7 @@ fn lobby_system(
     }
 
     // consume the channel (required because ggrs takes ownership of its socket)
-    let channel = socket.0.as_mut().unwrap().take_channel(0).unwrap();
+    let channel = socket.take_channel(0).unwrap();
 
     // start the GGRS session
     let sess = sess_build

--- a/examples/bevy_ggrs/src/main.rs
+++ b/examples/bevy_ggrs/src/main.rs
@@ -177,11 +177,8 @@ fn lobby_system(
 
     info!("All peers have joined, going in-game");
 
-    // consume the socket (currently required because ggrs takes ownership of its socket)
-    let socket = socket.0.take().unwrap();
-
     // extract final player list
-    let players = socket.players();
+    let players = socket.0.as_mut().unwrap().players();
 
     let max_prediction = 12;
 
@@ -199,9 +196,12 @@ fn lobby_system(
             .expect("failed to add player");
     }
 
+    // consume the channel (required because ggrs takes ownership of its socket)
+    let channel = socket.0.as_mut().unwrap().take_channel(0).unwrap();
+
     // start the GGRS session
     let sess = sess_build
-        .start_p2p_session(socket)
+        .start_p2p_session(channel)
         .expect("failed to start session");
 
     commands.insert_resource(Session::P2PSession(sess));

--- a/examples/bevy_ggrs/src/main.rs
+++ b/examples/bevy_ggrs/src/main.rs
@@ -1,7 +1,7 @@
 use bevy::{log::LogPlugin, prelude::*, tasks::IoTaskPool};
 use bevy_ggrs::{GGRSPlugin, Session};
 use ggrs::SessionBuilder;
-use matchbox_socket::{PeerState, WebRtcSocket};
+use matchbox_socket::{PeerState, WebRtcChannel, WebRtcSocket};
 
 mod args;
 mod box_game;
@@ -21,7 +21,7 @@ enum AppState {
 const SKY_COLOR: Color = Color::rgb(0.69, 0.69, 0.69);
 
 #[derive(Debug, Resource, Deref, DerefMut)]
-struct SocketResource(WebRtcSocket);
+struct SocketResource<C>(Option<WebRtcSocket<C>>);
 
 fn main() {
     // read query string or command line arguments
@@ -91,14 +91,14 @@ fn start_matchbox_socket(mut commands: Commands, args: Res<Args>) {
 
     let room_url = format!("{}/{}", &args.matchbox, room_id);
     info!("connecting to matchbox server: {:?}", room_url);
-    let (socket, message_loop) = WebRtcSocket::new_ggrs(room_url);
+    let (socket, message_loop) = WebRtcSocket::<WebRtcChannel>::new_ggrs(room_url);
 
     // The message loop needs to be awaited, or nothing will happen.
     // We do this here using bevy's task system.
     let task_pool = IoTaskPool::get();
     task_pool.spawn(message_loop).detach();
 
-    commands.insert_resource(SocketResource(socket));
+    commands.insert_resource(SocketResource(Some(socket)));
 }
 
 // Marker components for UI
@@ -155,12 +155,12 @@ fn lobby_cleanup(query: Query<Entity, With<LobbyUI>>, mut commands: Commands) {
 fn lobby_system(
     mut app_state: ResMut<State<AppState>>,
     args: Res<Args>,
-    mut socket: ResMut<SocketResource>,
+    mut socket: ResMut<SocketResource<WebRtcChannel>>,
     mut commands: Commands,
     mut query: Query<&mut Text, With<LobbyText>>,
 ) {
     // regularly call update_peers to update the list of connected peers
-    for (peer, new_state) in socket.update_peers() {
+    for (peer, new_state) in socket.0.as_mut().unwrap().update_peers() {
         // you can also handle the specific dis(connections) as they occur:
         match new_state {
             PeerState::Connected => info!("peer {peer:?} connected"),
@@ -168,7 +168,7 @@ fn lobby_system(
         }
     }
 
-    let connected_peers = socket.connected_peers().count();
+    let connected_peers = socket.0.as_ref().unwrap().connected_peers().count();
     let remaining = args.players - (connected_peers + 1);
     query.single_mut().sections[0].value = format!("Waiting for {remaining} more player(s)",);
     if remaining > 0 {
@@ -178,7 +178,7 @@ fn lobby_system(
     info!("All peers have joined, going in-game");
 
     // extract final player list
-    let players = socket.players();
+    let players = socket.0.as_ref().unwrap().players();
 
     let max_prediction = 12;
 
@@ -196,12 +196,9 @@ fn lobby_system(
             .expect("failed to add player");
     }
 
-    // consume the channel (required because ggrs takes ownership of its socket)
-    let channel = socket.take_channel(0).unwrap();
-
     // start the GGRS session
     let sess = sess_build
-        .start_p2p_session(channel)
+        .start_p2p_session(socket.0.take().unwrap())
         .expect("failed to start session");
 
     commands.insert_resource(Session::P2PSession(sess));

--- a/examples/bevy_ggrs/src/main.rs
+++ b/examples/bevy_ggrs/src/main.rs
@@ -1,7 +1,7 @@
 use bevy::{log::LogPlugin, prelude::*, tasks::IoTaskPool};
 use bevy_ggrs::{GGRSPlugin, Session};
 use ggrs::SessionBuilder;
-use matchbox_socket::{PeerState, WebRtcChannel, WebRtcSocket};
+use matchbox_socket::{PeerState, WebRtcSocket};
 
 mod args;
 mod box_game;
@@ -21,7 +21,7 @@ enum AppState {
 const SKY_COLOR: Color = Color::rgb(0.69, 0.69, 0.69);
 
 #[derive(Debug, Resource, Deref, DerefMut)]
-struct SocketResource<C>(Option<WebRtcSocket<C>>);
+struct SocketResource(Option<WebRtcSocket>);
 
 fn main() {
     // read query string or command line arguments
@@ -91,7 +91,7 @@ fn start_matchbox_socket(mut commands: Commands, args: Res<Args>) {
 
     let room_url = format!("{}/{}", &args.matchbox, room_id);
     info!("connecting to matchbox server: {:?}", room_url);
-    let (socket, message_loop) = WebRtcSocket::<WebRtcChannel>::new_ggrs(room_url);
+    let (socket, message_loop) = WebRtcSocket::new_ggrs(room_url);
 
     // The message loop needs to be awaited, or nothing will happen.
     // We do this here using bevy's task system.
@@ -155,7 +155,7 @@ fn lobby_cleanup(query: Query<Entity, With<LobbyUI>>, mut commands: Commands) {
 fn lobby_system(
     mut app_state: ResMut<State<AppState>>,
     args: Res<Args>,
-    mut socket: ResMut<SocketResource<WebRtcChannel>>,
+    mut socket: ResMut<SocketResource>,
     mut commands: Commands,
     mut query: Query<&mut Text, With<LobbyText>>,
 ) {

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -46,7 +46,7 @@ async fn async_main() {
                 PeerState::Connected => {
                     info!("Peer joined: {:?}", peer);
                     let packet = "hello friend!".as_bytes().to_vec().into_boxed_slice();
-                    socket.channel(0).as_mut().unwrap().send(packet, peer);
+                    socket.channel(0).unwrap().send(packet, peer);
                 }
                 PeerState::Disconnected => {
                     info!("Peer left: {peer:?}");

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -31,7 +31,7 @@ async fn main() {
 
 async fn async_main() {
     info!("Connecting to matchbox");
-    let (mut socket, loop_fut) = WebRtcSocket::new_reliable("ws://localhost:3536/");
+    let (mut socket, loop_fut) = WebRtcSocket::<()>::new_reliable("ws://localhost:3536/");
 
     let loop_fut = loop_fut.fuse();
     futures::pin_mut!(loop_fut);
@@ -46,7 +46,7 @@ async fn async_main() {
                 PeerState::Connected => {
                     info!("Peer joined: {:?}", peer);
                     let packet = "hello friend!".as_bytes().to_vec().into_boxed_slice();
-                    socket.channel(0).unwrap().send(packet, peer);
+                    socket.send(packet, peer);
                 }
                 PeerState::Disconnected => {
                     info!("Peer left: {peer:?}");
@@ -55,7 +55,7 @@ async fn async_main() {
         }
 
         // Accept any messages incoming
-        for (peer, packet) in socket.channel(0).unwrap().receive() {
+        for (peer, packet) in socket.receive() {
             let message = String::from_utf8_lossy(&packet);
             info!("Message from {peer:?}: {message:?}");
         }

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -46,7 +46,7 @@ async fn async_main() {
                 PeerState::Connected => {
                     info!("Peer joined: {:?}", peer);
                     let packet = "hello friend!".as_bytes().to_vec().into_boxed_slice();
-                    socket.send(packet, peer);
+                    socket.channel(0).as_mut().unwrap().send(packet, peer);
                 }
                 PeerState::Disconnected => {
                     info!("Peer left: {peer:?}");
@@ -55,7 +55,7 @@ async fn async_main() {
         }
 
         // Accept any messages incoming
-        for (peer, packet) in socket.receive() {
+        for (peer, packet) in socket.channel(0).unwrap().receive() {
             let message = String::from_utf8_lossy(&packet);
             info!("Message from {peer:?}: {message:?}");
         }

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -31,7 +31,7 @@ async fn main() {
 
 async fn async_main() {
     info!("Connecting to matchbox");
-    let (mut socket, loop_fut) = WebRtcSocket::<()>::new_reliable("ws://localhost:3536/");
+    let (mut socket, loop_fut) = WebRtcSocket::new_reliable("ws://localhost:3536/");
 
     let loop_fut = loop_fut.fuse();
     futures::pin_mut!(loop_fut);

--- a/matchbox_socket/src/ggrs_socket.rs
+++ b/matchbox_socket/src/ggrs_socket.rs
@@ -5,7 +5,7 @@ use crate::{
     ChannelConfig, MessageLoopFuture, Packet, WebRtcChannel, WebRtcSocket, WebRtcSocketBuilder,
 };
 
-impl<C> WebRtcSocket<C> {
+impl WebRtcSocket {
     /// Creates a [`WebRtcSocket`] and the corresponding [`MessageLoopFuture`] for a
     /// socket with a single channel configured correctly for usage with GGRS.
     ///
@@ -20,7 +20,9 @@ impl<C> WebRtcSocket<C> {
             .add_ggrs_channel()
             .build()
     }
+}
 
+impl<C> WebRtcSocket<C> {
     /// Returns a Vec of connected peers as [`ggrs::PlayerType`]
     pub fn players(&self) -> Vec<PlayerType<PeerId>> {
         let Some(our_id) = self.id() else {

--- a/matchbox_socket/src/ggrs_socket.rs
+++ b/matchbox_socket/src/ggrs_socket.rs
@@ -1,7 +1,7 @@
 use ggrs::{Message, PlayerType};
 use matchbox_protocol::PeerId;
 
-use crate::{ChannelConfig, MessageLoopFuture, WebRtcSocket, WebRtcSocketBuilder};
+use crate::{ChannelConfig, MessageLoopFuture, WebRtcChannel, WebRtcSocket, WebRtcSocketBuilder};
 
 impl WebRtcSocket {
     /// Creates a [`WebRtcSocket`] and the corresponding [`MessageLoopFuture`] for a
@@ -44,7 +44,7 @@ impl WebRtcSocket {
     }
 }
 
-impl ggrs::NonBlockingSocket<PeerId> for WebRtcSocket {
+impl ggrs::NonBlockingSocket<PeerId> for WebRtcChannel {
     fn send_to(&mut self, msg: &Message, addr: &PeerId) {
         let buf = bincode::serialize(&msg).unwrap();
         let packet = buf.into_boxed_slice();

--- a/matchbox_socket/src/ggrs_socket.rs
+++ b/matchbox_socket/src/ggrs_socket.rs
@@ -2,7 +2,8 @@ use ggrs::{Message, PlayerType};
 use matchbox_protocol::PeerId;
 
 use crate::{
-    ChannelConfig, MessageLoopFuture, Packet, WebRtcChannel, WebRtcSocket, WebRtcSocketBuilder,
+    ChannelConfig, MessageLoopFuture, Packet, SingleChannel, WebRtcChannel, WebRtcSocket,
+    WebRtcSocketBuilder,
 };
 
 impl ChannelConfig {
@@ -22,7 +23,7 @@ impl WebRtcSocket {
     /// Please use the [`WebRtcSocketBuilder`] to create non-trivial sockets.
     pub fn new_ggrs(
         room_url: impl Into<String>,
-    ) -> (WebRtcSocket<WebRtcChannel>, MessageLoopFuture) {
+    ) -> (WebRtcSocket<SingleChannel>, MessageLoopFuture) {
         WebRtcSocketBuilder::new(room_url)
             .add_channel(ChannelConfig::ggrs())
             .build()
@@ -65,7 +66,7 @@ fn deserialize_packet(message: (PeerId, Packet)) -> (PeerId, Message) {
     (message.0, bincode::deserialize(&message.1).unwrap())
 }
 
-impl ggrs::NonBlockingSocket<PeerId> for WebRtcSocket<WebRtcChannel> {
+impl ggrs::NonBlockingSocket<PeerId> for WebRtcSocket<SingleChannel> {
     fn send_to(&mut self, msg: &Message, addr: &PeerId) {
         self.send(build_packet(msg), *addr);
     }

--- a/matchbox_socket/src/ggrs_socket.rs
+++ b/matchbox_socket/src/ggrs_socket.rs
@@ -5,6 +5,13 @@ use crate::{
     ChannelConfig, MessageLoopFuture, Packet, WebRtcChannel, WebRtcSocket, WebRtcSocketBuilder,
 };
 
+impl ChannelConfig {
+    /// Creates a [`ChannelConfig`] suitable for use with GGRS.
+    pub fn ggrs() -> Self {
+        Self::unreliable()
+    }
+}
+
 impl WebRtcSocket {
     /// Creates a [`WebRtcSocket`] and the corresponding [`MessageLoopFuture`] for a
     /// socket with a single channel configured correctly for usage with GGRS.
@@ -16,8 +23,8 @@ impl WebRtcSocket {
     pub fn new_ggrs(
         room_url: impl Into<String>,
     ) -> (WebRtcSocket<WebRtcChannel>, MessageLoopFuture) {
-        WebRtcSocketBuilder::<WebRtcChannel>::new(room_url)
-            .add_ggrs_channel()
+        WebRtcSocketBuilder::new(room_url)
+            .add_channel(ChannelConfig::ggrs())
             .build()
     }
 }
@@ -74,13 +81,5 @@ impl ggrs::NonBlockingSocket<PeerId> for WebRtcChannel {
 
     fn receive_all_messages(&mut self) -> Vec<(PeerId, Message)> {
         self.receive().into_iter().map(deserialize_packet).collect()
-    }
-}
-
-impl<C> WebRtcSocketBuilder<C> {
-    /// Adds a new channel configured correctly for usage with GGRS to the [`WebRtcSocket`].
-    pub fn add_ggrs_channel(mut self) -> Self {
-        self.channels.push(ChannelConfig::unreliable());
-        self
     }
 }

--- a/matchbox_socket/src/ggrs_socket.rs
+++ b/matchbox_socket/src/ggrs_socket.rs
@@ -1,9 +1,11 @@
 use ggrs::{Message, PlayerType};
 use matchbox_protocol::PeerId;
 
-use crate::{ChannelConfig, MessageLoopFuture, WebRtcChannel, WebRtcSocket, WebRtcSocketBuilder};
+use crate::{
+    ChannelConfig, MessageLoopFuture, Packet, WebRtcChannel, WebRtcSocket, WebRtcSocketBuilder,
+};
 
-impl WebRtcSocket {
+impl<C> WebRtcSocket<C> {
     /// Creates a [`WebRtcSocket`] and the corresponding [`MessageLoopFuture`] for a
     /// socket with a single channel configured correctly for usage with GGRS.
     ///
@@ -11,8 +13,10 @@ impl WebRtcSocket {
     /// be sent and received.
     ///
     /// Please use the [`WebRtcSocketBuilder`] to create non-trivial sockets.
-    pub fn new_ggrs(room_url: impl Into<String>) -> (WebRtcSocket, MessageLoopFuture) {
-        WebRtcSocketBuilder::new(room_url)
+    pub fn new_ggrs(
+        room_url: impl Into<String>,
+    ) -> (WebRtcSocket<WebRtcChannel>, MessageLoopFuture) {
+        WebRtcSocketBuilder::<WebRtcChannel>::new(room_url)
             .add_ggrs_channel()
             .build()
     }
@@ -44,24 +48,34 @@ impl WebRtcSocket {
     }
 }
 
-impl ggrs::NonBlockingSocket<PeerId> for WebRtcChannel {
-    fn send_to(&mut self, msg: &Message, addr: &PeerId) {
-        let buf = bincode::serialize(&msg).unwrap();
-        let packet = buf.into_boxed_slice();
-        self.send(packet, *addr);
-    }
+fn build_packet(msg: &Message) -> Packet {
+    bincode::serialize(&msg).unwrap().into_boxed_slice()
+}
 
+fn deserialize_packet(message: (PeerId, Packet)) -> (PeerId, Message) {
+    (message.0, bincode::deserialize(&message.1).unwrap())
+}
+
+impl ggrs::NonBlockingSocket<PeerId> for WebRtcSocket<WebRtcChannel> {
+    fn send_to(&mut self, msg: &Message, addr: &PeerId) {
+        self.send(build_packet(msg), *addr);
+    }
     fn receive_all_messages(&mut self) -> Vec<(PeerId, Message)> {
-        let mut messages = vec![];
-        for (id, packet) in self.receive().into_iter() {
-            let msg = bincode::deserialize(&packet).unwrap();
-            messages.push((id, msg));
-        }
-        messages
+        self.receive().into_iter().map(deserialize_packet).collect()
     }
 }
 
-impl WebRtcSocketBuilder {
+impl ggrs::NonBlockingSocket<PeerId> for WebRtcChannel {
+    fn send_to(&mut self, msg: &Message, addr: &PeerId) {
+        self.send(build_packet(msg), *addr);
+    }
+
+    fn receive_all_messages(&mut self) -> Vec<(PeerId, Message)> {
+        self.receive().into_iter().map(deserialize_packet).collect()
+    }
+}
+
+impl<C> WebRtcSocketBuilder<C> {
     /// Adds a new channel configured correctly for usage with GGRS to the [`WebRtcSocket`].
     pub fn add_ggrs_channel(mut self) -> Self {
         self.channels.push(ChannelConfig::unreliable());

--- a/matchbox_socket/src/ggrs_socket.rs
+++ b/matchbox_socket/src/ggrs_socket.rs
@@ -22,7 +22,7 @@ impl WebRtcSocket {
     }
 }
 
-impl<C> WebRtcSocket<C> {
+impl WebRtcSocket {
     /// Returns a Vec of connected peers as [`ggrs::PlayerType`]
     pub fn players(&self) -> Vec<PlayerType<PeerId>> {
         let Some(our_id) = self.id() else {

--- a/matchbox_socket/src/lib.rs
+++ b/matchbox_socket/src/lib.rs
@@ -10,6 +10,7 @@ mod webrtc_socket;
 pub use error::Error;
 pub use matchbox_protocol::PeerId;
 pub use webrtc_socket::{
-    ChannelConfig, ChannelPlurality, MessageLoopFuture, MultipleChannels, NoChannels, Packet,
-    PeerState, RtcIceServerConfig, SingleChannel, WebRtcChannel, WebRtcSocket, WebRtcSocketBuilder,
+    BuildablePlurality, ChannelConfig, ChannelPlurality, MessageLoopFuture, MultipleChannels,
+    NoChannels, Packet, PeerState, RtcIceServerConfig, SingleChannel, WebRtcChannel, WebRtcSocket,
+    WebRtcSocketBuilder,
 };

--- a/matchbox_socket/src/lib.rs
+++ b/matchbox_socket/src/lib.rs
@@ -10,6 +10,6 @@ mod webrtc_socket;
 pub use error::Error;
 pub use matchbox_protocol::PeerId;
 pub use webrtc_socket::{
-    ChannelConfig, MessageLoopFuture, Packet, PeerState, RtcIceServerConfig, WebRtcSocket,
-    WebRtcSocketBuilder,
+    ChannelConfig, MessageLoopFuture, Packet, PeerState, RtcIceServerConfig, WebRtcChannel,
+    WebRtcSocket, WebRtcSocketBuilder,
 };

--- a/matchbox_socket/src/lib.rs
+++ b/matchbox_socket/src/lib.rs
@@ -10,6 +10,6 @@ mod webrtc_socket;
 pub use error::Error;
 pub use matchbox_protocol::PeerId;
 pub use webrtc_socket::{
-    ChannelConfig, MessageLoopFuture, Packet, PeerState, RtcIceServerConfig, WebRtcChannel,
-    WebRtcSocket, WebRtcSocketBuilder,
+    ChannelConfig, ChannelPlurality, MessageLoopFuture, MultipleChannels, NoChannels, Packet,
+    PeerState, RtcIceServerConfig, SingleChannel, WebRtcChannel, WebRtcSocket, WebRtcSocketBuilder,
 };

--- a/matchbox_socket/src/webrtc_socket/error.rs
+++ b/matchbox_socket/src/webrtc_socket/error.rs
@@ -3,11 +3,11 @@ use cfg_if::cfg_if;
 use futures_channel::mpsc::TrySendError;
 
 #[derive(Debug, thiserror::Error)]
-pub enum ChannelError {
+pub enum GetChannelError {
     #[error("This channel was never created")]
-    ChannelNotFound,
-    #[error("This channel has already been taken")]
-    ChannelTaken,
+    NotFound,
+    #[error("This channel has already been taken and is no longer on the socket")]
+    Taken,
 }
 
 /// An error that can occur with WebRTC signalling.

--- a/matchbox_socket/src/webrtc_socket/error.rs
+++ b/matchbox_socket/src/webrtc_socket/error.rs
@@ -2,6 +2,14 @@ use crate::webrtc_socket::messages::PeerEvent;
 use cfg_if::cfg_if;
 use futures_channel::mpsc::TrySendError;
 
+#[derive(Debug, thiserror::Error)]
+pub enum ChannelError {
+    #[error("This channel was never created")]
+    ChannelNotFound,
+    #[error("This channel has already been taken")]
+    ChannelTaken,
+}
+
 /// An error that can occur with WebRTC signalling.
 #[derive(Debug, thiserror::Error)]
 pub enum SignallingError {

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -126,9 +126,9 @@ trait Messenger {
     async fn peer_loop(peer_uuid: PeerId, handshake_meta: Self::HandshakeMeta) -> PeerId;
 }
 
-async fn message_loop<M: Messenger>(
+async fn message_loop<M: Messenger, C>(
     id_tx: crossbeam_channel::Sender<PeerId>,
-    config: WebRtcSocketBuilder,
+    config: WebRtcSocketBuilder<C>,
     channels: MessageLoopChannels,
 ) {
     let MessageLoopChannels {

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -14,7 +14,9 @@ use log::{debug, warn};
 use matchbox_protocol::PeerId;
 use messages::*;
 pub(crate) use socket::MessageLoopChannels;
-pub use socket::{ChannelConfig, PeerState, RtcIceServerConfig, WebRtcSocket, WebRtcSocketBuilder};
+pub use socket::{
+    ChannelConfig, PeerState, RtcIceServerConfig, WebRtcChannel, WebRtcSocket, WebRtcSocketBuilder,
+};
 use std::{collections::HashMap, pin::Pin, time::Duration};
 
 use self::error::{MessagingError, SignallingError};

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -3,6 +3,7 @@ mod messages;
 mod signal_peer;
 mod socket;
 
+use self::error::{MessagingError, SignallingError};
 use crate::{webrtc_socket::signal_peer::SignalPeer, Error};
 use async_trait::async_trait;
 use cfg_if::cfg_if;
@@ -15,11 +16,10 @@ use matchbox_protocol::PeerId;
 use messages::*;
 pub(crate) use socket::MessageLoopChannels;
 pub use socket::{
-    ChannelConfig, PeerState, RtcIceServerConfig, WebRtcChannel, WebRtcSocket, WebRtcSocketBuilder,
+    ChannelConfig, ChannelPlurality, MultipleChannels, NoChannels, PeerState, RtcIceServerConfig,
+    SingleChannel, WebRtcChannel, WebRtcSocket, WebRtcSocketBuilder,
 };
 use std::{collections::HashMap, pin::Pin, time::Duration};
-
-use self::error::{MessagingError, SignallingError};
 
 cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
@@ -126,7 +126,7 @@ trait Messenger {
     async fn peer_loop(peer_uuid: PeerId, handshake_meta: Self::HandshakeMeta) -> PeerId;
 }
 
-async fn message_loop<M: Messenger, C>(
+async fn message_loop<M: Messenger, C: ChannelPlurality>(
     id_tx: crossbeam_channel::Sender<PeerId>,
     config: WebRtcSocketBuilder<C>,
     channels: MessageLoopChannels,

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -397,6 +397,14 @@ impl WebRtcSocket {
     }
 }
 
+pub(crate) fn new_senders_and_receivers<T>(
+    channel_configs: &[ChannelConfig],
+) -> (Vec<UnboundedSender<T>>, Vec<UnboundedReceiver<T>>) {
+    (0..channel_configs.len())
+        .map(|_| futures_channel::mpsc::unbounded())
+        .unzip()
+}
+
 pub(crate) fn create_data_channels_ready_fut(
     channel_configs: &[ChannelConfig],
 ) -> (

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -1,4 +1,4 @@
-use super::error::ChannelError;
+use super::error::GetChannelError;
 use crate::{
     webrtc_socket::{
         message_loop, signalling_loop, MessageLoopFuture, Packet, PeerEvent, PeerRequest,
@@ -410,12 +410,12 @@ impl<C: ChannelPlurality> WebRtcSocket<C> {
     /// ```
     ///
     /// See also: [`WebRtcSocket::take_channel`]
-    pub fn channel(&mut self, channel: usize) -> Result<&mut WebRtcChannel, ChannelError> {
+    pub fn channel(&mut self, channel: usize) -> Result<&mut WebRtcChannel, GetChannelError> {
         self.channels
             .get_mut(channel)
-            .ok_or(ChannelError::ChannelNotFound)?
+            .ok_or(GetChannelError::NotFound)?
             .as_mut()
-            .ok_or(ChannelError::ChannelTaken)
+            .ok_or(GetChannelError::Taken)
     }
 
     /// Takes the [`WebRtcChannel`] of a given id.
@@ -432,12 +432,12 @@ impl<C: ChannelPlurality> WebRtcSocket<C> {
     /// ```
     ///
     /// See also: [`WebRtcSocket::channel`]
-    pub fn take_channel(&mut self, channel: usize) -> Result<WebRtcChannel, ChannelError> {
+    pub fn take_channel(&mut self, channel: usize) -> Result<WebRtcChannel, GetChannelError> {
         self.channels
             .get_mut(channel)
-            .ok_or(ChannelError::ChannelNotFound)?
+            .ok_or(GetChannelError::NotFound)?
             .take()
-            .ok_or(ChannelError::ChannelTaken)
+            .ok_or(GetChannelError::Taken)
     }
 }
 

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -198,7 +198,7 @@ impl<C: BuildablePlurality> WebRtcSocketBuilder<C> {
     /// The returned [`MessageLoopFuture`] should be awaited in order for messages to be sent and received.
     pub fn build(self) -> (WebRtcSocket<C>, MessageLoopFuture) {
         if self.config.channels.is_empty() {
-            panic!("You need to configure at least one channel in WebRtcSocketBuilder");
+            unreachable!();
         }
 
         let (peer_state_tx, peer_state_rx) = futures_channel::mpsc::unbounded();

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -256,7 +256,8 @@ pub enum PeerState {
     /// - The peer left the signalling server
     Disconnected,
 }
-/// Used to send and recieve packets on a given web rtc channel
+/// Used to send and recieve packets on a given web rtc channel. Must be created as part of a
+/// [`WebRtcSocket`].
 #[derive(Debug)]
 pub struct WebRtcChannel {
     tx: UnboundedSender<(PeerId, Packet)>,
@@ -416,8 +417,6 @@ impl WebRtcSocket<WebRtcChannel> {
 impl WebRtcSocket<WebRtcChannels> {
     /// Gets a reference to the [`WebRtcChannel`] of a given id.
     ///
-    /// # Examples
-    ///
     /// ```
     /// use matchbox_socket::*;
     ///
@@ -425,8 +424,7 @@ impl WebRtcSocket<WebRtcChannels> {
     ///     .add_channel(ChannelConfig::reliable())
     ///     .add_channel(ChannelConfig::unreliable())
     ///     .build();
-    /// let reliable_channel = socket.take_channel(0).unwrap();
-    /// let unreliable_channel = socket.take_channel(1).unwrap();
+    /// let reliable_channel_messages = socket.channel(0).unwrap().receive();
     /// ```
     ///
     /// See also: [`WebRtcSocket::take_channel`]
@@ -439,6 +437,17 @@ impl WebRtcSocket<WebRtcChannels> {
     }
 
     /// Takes the [`WebRtcChannel`] of a given id.
+    ///
+    /// ```
+    /// use matchbox_socket::*;
+    ///
+    /// let (mut socket, message_loop) = WebRtcSocketBuilder::new("wss://example.invalid/")
+    ///     .add_channel(ChannelConfig::reliable())
+    ///     .add_channel(ChannelConfig::unreliable())
+    ///     .build();
+    /// let reliable_channel = socket.take_channel(0).unwrap();
+    /// let unreliable_channel = socket.take_channel(1).unwrap();
+    /// ```
     ///
     /// See also: [`WebRtcSocket::channel`]
     pub fn take_channel(&mut self, channel: usize) -> Result<WebRtcChannel, ChannelError> {

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -277,7 +277,7 @@ type WebRtcChannels = Vec<Option<WebRtcChannel>>;
 
 /// Contains a set of web rtc channels and some connection metadata.
 #[derive(Debug)]
-pub struct WebRtcSocket<C> {
+pub struct WebRtcSocket<C = WebRtcChannel> {
     id: once_cell::race::OnceBox<PeerId>,
     id_rx: crossbeam_channel::Receiver<PeerId>,
     peer_state_rx: futures_channel::mpsc::UnboundedReceiver<(PeerId, PeerState)>,

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -92,7 +92,7 @@ pub struct SingleChannel;
 impl ChannelPlurality for SingleChannel {}
 impl BuildablePlurality for SingleChannel {}
 
-/// Inicates that type has more than one [`WebRtcChannel`]s or [`ChannelConfig`]s.
+/// Indicates that the type has more than one [`WebRtcChannel`]s or [`ChannelConfig`]s.
 #[derive(Debug)]
 pub struct MultipleChannels;
 impl ChannelPlurality for MultipleChannels {}

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -421,6 +421,19 @@ impl WebRtcSocket<WebRtcChannel> {
 impl WebRtcSocket<WebRtcChannels> {
     /// Gets a reference to the [`WebRtcChannel`] of a given id.
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// use matchbox_socket::*;
+    ///
+    /// let (mut socket, message_loop) = WebRtcSocketBuilder::new("wss://example.invalid/")
+    ///     .add_channel(ChannelConfig::reliable())
+    ///     .add_channel(ChannelConfig::unreliable())
+    ///     .build();
+    /// let reliable_channel = socket.take_channel(0).unwrap();
+    /// let unreliable_channel = socket.take_channel(1).unwrap();
+    /// ```
+    ///
     /// See also: [`WebRtcSocket::take_channel`]
     pub fn channel(&mut self, channel: usize) -> Result<&mut WebRtcChannel, ChannelError> {
         self.channels

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -295,8 +295,7 @@ impl WebRtcSocket {
             .build()
     }
 
-    /// Gets a reference to the [`WebRtcChannel`] of a given id. May return [`None`] if
-    /// the channel has been taken.
+    /// Gets a reference to the [`WebRtcChannel`] of a given id.
     ///
     /// See also: [`WebRtcSocket::take_channel`]
     pub fn channel(&mut self, channel: usize) -> Result<&mut WebRtcChannel, ChannelError> {
@@ -307,8 +306,7 @@ impl WebRtcSocket {
             .ok_or(ChannelError::ChannelTaken)
     }
 
-    /// Takes the [`WebRtcChannel`] of a given id. May return [`None`] if the channel
-    /// has been taken.
+    /// Takes the [`WebRtcChannel`] of a given id.
     ///
     /// See also: [`WebRtcSocket::channel`]
     pub fn take_channel(&mut self, channel: usize) -> Result<WebRtcChannel, ChannelError> {

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -81,7 +81,7 @@ impl Default for RtcIceServerConfig {
 /// [`WebRtcSocketBuilder::add_unreliable_channel`] before calling
 /// [`WebRtcSocketBuilder::build`] to produce the desired [`WebRtcSocket`].
 #[derive(Debug, Clone)]
-pub struct WebRtcSocketBuilder<C> {
+pub struct WebRtcSocketBuilder<C = WebRtcChannel> {
     /// The url for the room to connect to
     ///
     /// This is a websocket url, starting with `ws://` or `wss://` followed by
@@ -103,7 +103,7 @@ pub struct WebRtcSocketBuilder<C> {
     channel_plurality: PhantomData<C>,
 }
 
-impl<C> WebRtcSocketBuilder<C> {
+impl WebRtcSocketBuilder {
     /// Creates a new builder for a connection to a given room with the default ICE
     /// server configuration, and three reconnection attempts.
     ///
@@ -285,7 +285,7 @@ pub struct WebRtcSocket<C = WebRtcChannel> {
     channels: C,
 }
 
-impl<C> WebRtcSocket<C> {
+impl WebRtcSocket {
     /// Creates a new builder for a connection to a given room with a given number of
     /// re-connection attempts.
     ///
@@ -293,7 +293,7 @@ impl<C> WebRtcSocket<C> {
     /// [`WebRtcSocketBuilder::add_reliable_channel`], or
     /// [`WebRtcSocketBuilder::add_unreliable_channel`] before you can build the
     /// [`WebRtcSocket`]
-    pub fn builder(room_url: impl Into<String>) -> WebRtcSocketBuilder<C> {
+    pub fn builder(room_url: impl Into<String>) -> WebRtcSocketBuilder {
         WebRtcSocketBuilder::new(room_url)
     }
 
@@ -307,7 +307,7 @@ impl<C> WebRtcSocket<C> {
     pub fn new_unreliable(
         room_url: impl Into<String>,
     ) -> (WebRtcSocket<WebRtcChannel>, MessageLoopFuture) {
-        WebRtcSocketBuilder::<WebRtcChannel>::new(room_url)
+        WebRtcSocketBuilder::new(room_url)
             .add_unreliable_channel()
             .build()
     }
@@ -322,7 +322,7 @@ impl<C> WebRtcSocket<C> {
     pub fn new_reliable(
         room_url: impl Into<String>,
     ) -> (WebRtcSocket<WebRtcChannel>, MessageLoopFuture) {
-        WebRtcSocketBuilder::<WebRtcChannel>::new(room_url)
+        WebRtcSocketBuilder::new(room_url)
             .add_reliable_channel()
             .build()
     }
@@ -530,7 +530,7 @@ mod test {
     #[futures_test::test]
     async fn unreachable_server() {
         // .invalid is a reserved tld for testing and documentation
-        let (_socket, fut) = WebRtcSocketBuilder::<WebRtcChannel>::new("wss://example.invalid")
+        let (_socket, fut) = WebRtcSocketBuilder::new("wss://example.invalid")
             .add_reliable_channel()
             .build();
 

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -166,13 +166,7 @@ impl WebRtcSocketBuilder<WebRtcChannels> {
     /// Adds a new channel to the [`WebRtcSocket`] configuration according to a [`ChannelConfig`].
     pub fn add_channel(mut self, config: ChannelConfig) -> WebRtcSocketBuilder<WebRtcChannels> {
         self.channels.push(config);
-        WebRtcSocketBuilder {
-            room_url: self.room_url,
-            ice_server: self.ice_server,
-            channels: self.channels,
-            attempts: self.attempts,
-            channel_plurality: PhantomData::default(),
-        }
+        self
     }
 }
 

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -397,7 +397,7 @@ impl<C: ChannelPlurality> WebRtcSocket<C> {
         }
     }
 
-    /// Gets a reference to the [`WebRtcChannel`] of a given id.
+    /// Gets a mutable reference to the [`WebRtcChannel`] of a given id.
     ///
     /// ```
     /// use matchbox_socket::*;

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -11,6 +11,8 @@ use log::{debug, error};
 use matchbox_protocol::PeerId;
 use std::{collections::HashMap, pin::Pin};
 
+use super::error::ChannelError;
+
 /// Configuration options for an ICE server connection.
 /// See also: <https://developer.mozilla.org/en-US/docs/Web/API/RTCIceServer#example>
 #[derive(Debug, Clone)]
@@ -313,22 +315,24 @@ impl WebRtcSocket {
     /// the channel has been taken.
     ///
     /// See also: [`WebRtcSocket::take_channel`]
-    pub fn channel(&mut self, channel: usize) -> Option<&mut WebRtcChannel> {
+    pub fn channel(&mut self, channel: usize) -> Result<&mut WebRtcChannel, ChannelError> {
         self.channels
             .get_mut(channel)
-            .expect(&format!("No channel exists with id {channel}"))
+            .ok_or(ChannelError::ChannelNotFound)?
             .as_mut()
+            .ok_or(ChannelError::ChannelTaken)
     }
 
     /// Takes the [`WebRtcChannel`] of a given id. May return [`None`] if the channel
     /// has been taken.
     ///
     /// See also: [`WebRtcSocket::channel`]
-    pub fn take_channel(&mut self, channel: usize) -> Option<WebRtcChannel> {
+    pub fn take_channel(&mut self, channel: usize) -> Result<WebRtcChannel, ChannelError> {
         self.channels
             .get_mut(channel)
-            .expect(&format!("No channel exists with id {channel}"))
+            .ok_or(ChannelError::ChannelNotFound)?
             .take()
+            .ok_or(ChannelError::ChannelTaken)
     }
 
     /// Handle peers connecting or disconnecting

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -253,7 +253,7 @@ pub enum PeerState {
     /// - The peer left the signalling server
     Disconnected,
 }
-/// Used to send and recieve packets on a given web rtc channel. Must be created as part of a
+/// Used to send and receive packets on a given WebRTC channel. Must be created as part of a
 /// [`WebRtcSocket`].
 #[derive(Debug)]
 pub struct WebRtcChannel {

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -275,10 +275,6 @@ impl WebRtcChannel {
 
 type WebRtcChannels = Vec<Option<WebRtcChannel>>;
 
-trait ChannelSend {
-    fn send(&mut self, packet: Packet, peer: PeerId);
-}
-
 /// Contains a set of web rtc channels and some connection metadata.
 #[derive(Debug)]
 pub struct WebRtcSocket<C> {

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -328,7 +328,9 @@ impl WebRtcSocket {
             .add_channel(ChannelConfig::reliable())
             .build()
     }
+}
 
+impl<C: ChannelPlurality> WebRtcSocket<C> {
     /// Handle peers connecting or disconnecting
     ///
     /// Constructed using [`WebRtcSocketBuilder`].

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -76,9 +76,7 @@ impl Default for RtcIceServerConfig {
 /// Builder for [`WebRtcSocket`]s.
 ///
 /// Begin with [`WebRtcSocketBuilder::new`] and add at least one channel with
-/// [`WebRtcSocketBuilder::add_channel`],
-/// [`WebRtcSocketBuilder::add_reliable_channel`], or
-/// [`WebRtcSocketBuilder::add_unreliable_channel`] before calling
+/// [`WebRtcSocketBuilder::add_channel`] before calling
 /// [`WebRtcSocketBuilder::build`] to produce the desired [`WebRtcSocket`].
 #[derive(Debug, Clone)]
 pub struct WebRtcSocketBuilder<C = ()> {
@@ -107,10 +105,8 @@ impl WebRtcSocketBuilder {
     /// Creates a new builder for a connection to a given room with the default ICE
     /// server configuration, and three reconnection attempts.
     ///
-    /// You must add at least one channel with [`WebRtcSocketBuilder::add_channel`],
-    /// [`WebRtcSocketBuilder::add_reliable_channel`], or
-    /// [`WebRtcSocketBuilder::add_unreliable_channel`] before you can build the
-    /// [`WebRtcSocket`]
+    /// You must add at least one channel with [`WebRtcSocketBuilder::add_channel`]
+    /// before you can build the [`WebRtcSocket`]
     pub fn new(room_url: impl Into<String>) -> Self {
         Self {
             room_url: room_url.into(),
@@ -300,10 +296,8 @@ impl WebRtcSocket {
     /// Creates a new builder for a connection to a given room with a given number of
     /// re-connection attempts.
     ///
-    /// You must add at least one channel with [`WebRtcSocketBuilder::add_channel`],
-    /// [`WebRtcSocketBuilder::add_reliable_channel`], or
-    /// [`WebRtcSocketBuilder::add_unreliable_channel`] before you can build the
-    /// [`WebRtcSocket`]
+    /// You must add at least one channel with [`WebRtcSocketBuilder::add_channel`]
+    /// before you can build the [`WebRtcSocket`]
     pub fn builder(room_url: impl Into<String>) -> WebRtcSocketBuilder {
         WebRtcSocketBuilder::new(room_url)
     }
@@ -342,13 +336,13 @@ impl WebRtcSocket {
     ///
     /// Constructed using [`WebRtcSocketBuilder`].
     ///
-    /// Update the set of peers used by [`connected_peers`],
-    /// [`disconnected_peers`], and [`broadcast_on_channel`].
+    /// Update the set of peers used by [`WebRtcSocket::connected_peers`] and
+    /// [`WebRtcSocket::disconnected_peers`].
     ///
     /// Returns the peers that connected or disconnected since the last time
     /// this method was called.
     ///
-    /// See also: [`PeerSate`]
+    /// See also: [`PeerState`]
     pub fn update_peers(&mut self) -> Vec<(PeerId, PeerState)> {
         let mut changes = Vec::new();
         while let Ok(Some((id, state))) = self.peer_state_rx.try_next() {
@@ -362,7 +356,7 @@ impl WebRtcSocket {
 
     /// Returns an iterator of the ids of the connected peers.
     ///
-    /// Note: You have to call [`update_peers`] for this list to be accurate.
+    /// Note: You have to call [`WebRtcSocket::update_peers`] for this list to be accurate.
     ///
     /// See also: [`WebRtcSocket::disconnected_peers`]
     pub fn connected_peers(&'_ self) -> impl std::iter::Iterator<Item = PeerId> + '_ {
@@ -377,7 +371,8 @@ impl WebRtcSocket {
 
     /// Returns an iterator of the ids of peers that are no longer connected.
     ///
-    /// Note: You have to call [`update_peers`] for this list to be accurate.
+    /// Note: You have to call [`WebRtcSocket::update_peers`] for this list to be
+    /// accurate.
     ///
     /// See also: [`WebRtcSocket::connected_peers`]
     pub fn disconnected_peers(&self) -> impl std::iter::Iterator<Item = &PeerId> {

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -278,7 +278,7 @@ impl WebRtcChannel {
     }
 }
 
-/// Contains a set of web rtc channels and some connection metadata.
+/// Contains a set of [`WebRtcChannel`]s and connection metadata.
 #[derive(Debug)]
 pub struct WebRtcSocket<C: ChannelPlurality = SingleChannel> {
     id: once_cell::race::OnceBox<PeerId>,

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -86,7 +86,7 @@ pub trait BuildablePlurality: ChannelPlurality {}
 pub struct NoChannels;
 impl ChannelPlurality for NoChannels {}
 
-/// Inicates that type has exactly one [`WebRtcChannel`] or [`ChannelConfig`].
+/// Indicates that the type has exactly one [`WebRtcChannel`] or [`ChannelConfig`].
 #[derive(Debug)]
 pub struct SingleChannel;
 impl ChannelPlurality for SingleChannel {}

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -81,7 +81,7 @@ pub trait ChannelPlurality {}
 /// used to build a [`WebRtcSocket`].
 pub trait BuildablePlurality: ChannelPlurality {}
 
-/// Inicates that type has no [`WebRtcChannel`]s or [`ChannelConfig`]s.
+/// Indicates that the type has no [`WebRtcChannel`]s or [`ChannelConfig`]s.
 #[derive(Debug)]
 pub struct NoChannels;
 impl ChannelPlurality for NoChannels {}

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -396,33 +396,7 @@ impl WebRtcSocket {
             None
         }
     }
-}
 
-impl WebRtcSocket<SingleChannel> {
-    /// Call this where you want to handle new received messages.
-    ///
-    /// Messages are removed from the socket when called.
-    pub fn receive(&mut self) -> Vec<(PeerId, Packet)> {
-        self.channels
-            .get_mut(0)
-            .unwrap()
-            .as_mut()
-            .unwrap()
-            .receive()
-    }
-
-    /// Send a packet to the given peer.
-    pub fn send(&mut self, packet: Packet, peer: PeerId) {
-        self.channels
-            .get_mut(0)
-            .unwrap()
-            .as_mut()
-            .unwrap()
-            .send(packet, peer)
-    }
-}
-
-impl WebRtcSocket<MultipleChannels> {
     /// Gets a reference to the [`WebRtcChannel`] of a given id.
     ///
     /// ```
@@ -464,6 +438,30 @@ impl WebRtcSocket<MultipleChannels> {
             .ok_or(ChannelError::ChannelNotFound)?
             .take()
             .ok_or(ChannelError::ChannelTaken)
+    }
+}
+
+impl WebRtcSocket<SingleChannel> {
+    /// Call this where you want to handle new received messages.
+    ///
+    /// Messages are removed from the socket when called.
+    pub fn receive(&mut self) -> Vec<(PeerId, Packet)> {
+        self.channels
+            .get_mut(0)
+            .unwrap()
+            .as_mut()
+            .unwrap()
+            .receive()
+    }
+
+    /// Send a packet to the given peer.
+    pub fn send(&mut self, packet: Packet, peer: PeerId) {
+        self.channels
+            .get_mut(0)
+            .unwrap()
+            .as_mut()
+            .unwrap()
+            .send(packet, peer)
     }
 }
 


### PR DESCRIPTION
Again, with a view towards making multi-channel sockets easier to use, I've abstracted channels by implementing a `WebRtcChannel` struct which provides `send` & `receive`. This should make the code from @johanhelsing's [last devblog](https://johanhelsing.studio/posts/cargo-space-devlog-6) a lot cleaner.

Unfortunately I've had to drop `broadcast` as it would require channels to know about their peers, it wasn't in use anywhere as far as I can tell, though maybe we should still figure out a way of re-adding it