### PR TITLE
Use `rust-cache` to speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
           toolchain: stable
           override: true
 
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.2.1
+
       - name: Run cargo check
         uses: actions-rs/cargo@v1
         with:
@@ -38,6 +41,9 @@ jobs:
           toolchain: stable
           target: wasm32-unknown-unknown
           override: true
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.2.1
 
       - name: Run cargo check
         uses: actions-rs/cargo@v1
@@ -59,6 +65,9 @@ jobs:
           toolchain: stable
           override: true
 
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.2.1
+
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
@@ -78,6 +87,9 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.2.1
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
@@ -106,6 +118,9 @@ jobs:
           target: wasm32-unknown-unknown
           override: true
           components: clippy
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.2.1
 
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,3 +184,5 @@ jobs:
           load: ${{ ! (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Adds the [rust-cache action](https://github.com/Swatinem/rust-cache) to our CI steps to cache dependency download & incremental compilation