### PR TITLE
Split CI into Code & Markdown Lint

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -2,7 +2,7 @@ on:
   push:
   pull_request:
 
-name: ci
+name: Code
 
 jobs:
   check-native:
@@ -127,22 +127,6 @@ jobs:
         with:
           command: clippy
           args: --target wasm32-unknown-unknown -p matchbox_socket -p bevy_ggrs_example -p simple_example -- -D warnings
-
-  markdownlint:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          # full git history is needed to get a proper list of changed files within `super-linter`
-          fetch-depth: 0
-      - name: Run Markdown Lint
-        uses: docker://ghcr.io/github/super-linter:slim-v4
-        env:
-          MULTI_STATUS: false
-          VALIDATE_ALL_CODEBASE: false
-          VALIDATE_MARKDOWN: true
-          DEFAULT_BRANCH: main
 
   server-container:
     name: Build & Push Server Container

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,22 @@
+on:
+  push:
+  pull_request:
+
+name: Markdown Lint
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+      - name: Run Markdown Lint
+        uses: docker://ghcr.io/github/super-linter:slim-v4
+        env:
+          MULTI_STATUS: false
+          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_MARKDOWN: true
+          DEFAULT_BRANCH: main


### PR DESCRIPTION
Splits the one CI job into two, one for Code CI and one for linting markdown. Just makes the CI a bit easier to understand and brings consistency with #163 