### PR TITLE
Rename `ggrs-socket` feature to `ggrs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ p2p connections in web browsers or native to facilitate low-latency multiplayer 
 The Matchbox project contains:
 
 - A socket abstraction, [matchbox_socket](https://github.com/johanhelsing/matchbox/tree/main/matchbox_socket)
-  - With a feature, `ggrs-socket` for providing a [ggrs](https://github.com/gschup/ggrs) compatible socket.
+  - With a feature, `ggrs` for providing a [ggrs](https://github.com/gschup/ggrs) compatible socket.
 - A tiny signaling server, [matchbox_server](https://github.com/johanhelsing/matchbox/tree/main/matchbox_server). Written in rust, uses only a couple of megabytes of memory. Also available as a docker image. Compatible with all demos.
 - A signaling server API, [matchbox_signaling](https://github.com/johanhelsing/matchbox/tree/main/matchbox_signaling). For DIY signaling servers and hookable callbacks, this may be useful if you plan a complicated matchmaking procedure.
 

--- a/examples/bevy_ggrs/Cargo.toml
+++ b/examples/bevy_ggrs/Cargo.toml
@@ -19,7 +19,7 @@ ggrs = { version = "0.9", features = ["wasm-bindgen"] }
 
 [dependencies]
 bevy_matchbox = { path = "../../bevy_matchbox" }
-matchbox_socket = { path = "../../matchbox_socket", features = ["ggrs-socket"] }
+matchbox_socket = { path = "../../matchbox_socket", features = ["ggrs"] }
 bevy = { version = "0.9", default-features = false, features = [
   "bevy_gltf",
   "bevy_winit",

--- a/matchbox_socket/Cargo.toml
+++ b/matchbox_socket/Cargo.toml
@@ -15,7 +15,7 @@ categories = [
 repository = "https://github.com/johanhelsing/matchbox"
 
 [features]
-ggrs-socket = ["dep:bincode", "dep:ggrs"]
+ggrs = ["dep:bincode", "dep:ggrs"]
 
 [dependencies]
 matchbox_protocol = { path = "../matchbox_protocol", default-features = false }

--- a/matchbox_socket/src/lib.rs
+++ b/matchbox_socket/src/lib.rs
@@ -3,7 +3,7 @@
 #![forbid(unsafe_code)]
 
 mod error;
-#[cfg(feature = "ggrs-socket")]
+#[cfg(feature = "ggrs")]
 mod ggrs_socket;
 mod webrtc_socket;
 


### PR DESCRIPTION
The common convention seems to be that crate integration features should just be named after the crate they integrate with.

https://rust-lang.github.io/api-guidelines/naming.html#feature-names-are-free-of-placeholder-words-c-feature

Also, gets rid of a dash. Otherwise, I think we're entirely in camp understcore, like Bevy.