### PR TITLE
Add `get_channel`, make `channel` panicky

### DIFF
--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -426,11 +426,34 @@ impl<C: ChannelPlurality> WebRtcSocket<C> {
     ///     .add_channel(ChannelConfig::reliable())
     ///     .add_channel(ChannelConfig::unreliable())
     ///     .build();
+    /// let reliable_channel_messages = socket.channel(0).receive();
+    /// ```
+    ///
+    /// See also: [`WebRtcSocket::get_channel`], [`WebRtcSocket::take_channel`]
+    ///
+    /// # Panics
+    ///
+    /// will panic if the channel cannot be found.
+    pub fn channel(&mut self, channel: usize) -> &mut WebRtcChannel {
+        self.get_channel(channel).unwrap()
+    }
+
+    /// Gets a mutable reference to the [`WebRtcChannel`] of a given id.
+    ///
+    /// Returns an error if the channel was not found.
+    ///
+    /// ```
+    /// use matchbox_socket::*;
+    ///
+    /// let (mut socket, message_loop) = WebRtcSocketBuilder::new("wss://example.invalid/")
+    ///     .add_channel(ChannelConfig::reliable())
+    ///     .add_channel(ChannelConfig::unreliable())
+    ///     .build();
     /// let reliable_channel_messages = socket.channel(0).unwrap().receive();
     /// ```
     ///
-    /// See also: [`WebRtcSocket::take_channel`]
-    pub fn channel(&mut self, channel: usize) -> Result<&mut WebRtcChannel, GetChannelError> {
+    /// See also: [`WebRtcSocket::channel`], [`WebRtcSocket::take_channel`]
+    pub fn get_channel(&mut self, channel: usize) -> Result<&mut WebRtcChannel, GetChannelError> {
         self.channels
             .get_mut(channel)
             .ok_or(GetChannelError::NotFound)?

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -449,7 +449,7 @@ impl<C: ChannelPlurality> WebRtcSocket<C> {
     ///     .add_channel(ChannelConfig::reliable())
     ///     .add_channel(ChannelConfig::unreliable())
     ///     .build();
-    /// let reliable_channel_messages = socket.channel(0).unwrap().receive();
+    /// let reliable_channel_messages = socket.get_channel(0).unwrap().receive();
     /// ```
     ///
     /// See also: [`WebRtcSocket::channel`], [`WebRtcSocket::take_channel`]


### PR DESCRIPTION
I think taking channels out is probably a bit uncommon, would probably be nice to provide the discussed panicky convenience.