### PR TITLE
Make tests pass on windows

### DIFF
--- a/matchbox_server/src/signaling.rs
+++ b/matchbox_server/src/signaling.rs
@@ -296,7 +296,7 @@ mod tests {
 
     #[tokio::test]
     async fn ws_connect() {
-        let server = axum::Server::bind(&SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)))
+        let server = axum::Server::bind(&SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
             .serve(app().into_make_service_with_connect_info::<SocketAddr>());
         let addr = server.local_addr();
         tokio::spawn(server);
@@ -308,7 +308,7 @@ mod tests {
 
     #[tokio::test]
     async fn uuid_assigned() {
-        let server = axum::Server::bind(&SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)))
+        let server = axum::Server::bind(&SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
             .serve(app().into_make_service_with_connect_info::<SocketAddr>());
         let addr = server.local_addr();
         tokio::spawn(server);
@@ -325,7 +325,7 @@ mod tests {
 
     #[tokio::test]
     async fn new_peer() {
-        let server = axum::Server::bind(&SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)))
+        let server = axum::Server::bind(&SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
             .serve(app().into_make_service_with_connect_info::<SocketAddr>());
         let addr = server.local_addr();
         tokio::spawn(server);
@@ -351,7 +351,7 @@ mod tests {
 
     #[tokio::test]
     async fn disconnect_peer() {
-        let server = axum::Server::bind(&SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)))
+        let server = axum::Server::bind(&SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
             .serve(app().into_make_service_with_connect_info::<SocketAddr>());
         let addr = server.local_addr();
         tokio::spawn(server);
@@ -383,7 +383,7 @@ mod tests {
 
     #[tokio::test]
     async fn signal() {
-        let server = axum::Server::bind(&SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)))
+        let server = axum::Server::bind(&SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
             .serve(app().into_make_service_with_connect_info::<SocketAddr>());
         let addr = server.local_addr();
         tokio::spawn(server);
@@ -426,7 +426,7 @@ mod tests {
 
     #[tokio::test]
     async fn match_pairs() {
-        let server = axum::Server::bind(&SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)))
+        let server = axum::Server::bind(&SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
             .serve(app().into_make_service_with_connect_info::<SocketAddr>());
         let addr = server.local_addr();
         tokio::spawn(server);
@@ -478,7 +478,7 @@ mod tests {
     }
     #[tokio::test]
     async fn match_pair_and_other_alone_room_without_next() {
-        let server = axum::Server::bind(&SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)))
+        let server = axum::Server::bind(&SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
             .serve(app().into_make_service_with_connect_info::<SocketAddr>());
         let addr = server.local_addr();
         tokio::spawn(server);
@@ -521,7 +521,7 @@ mod tests {
 
     #[tokio::test]
     async fn match_different_id_same_next() {
-        let server = axum::Server::bind(&SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)))
+        let server = axum::Server::bind(&SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
             .serve(app().into_make_service_with_connect_info::<SocketAddr>());
         let addr = server.local_addr();
         tokio::spawn(server);
@@ -573,7 +573,7 @@ mod tests {
     }
     #[tokio::test]
     async fn match_same_id_different_next() {
-        let server = axum::Server::bind(&SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)))
+        let server = axum::Server::bind(&SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
             .serve(app().into_make_service_with_connect_info::<SocketAddr>());
         let addr = server.local_addr();
         tokio::spawn(server);

--- a/matchbox_signaling/tests/client_server.rs
+++ b/matchbox_signaling/tests/client_server.rs
@@ -48,7 +48,7 @@ mod tests {
 
     #[tokio::test]
     async fn ws_connect() {
-        let server = SignalingServer::client_server_builder((Ipv4Addr::UNSPECIFIED, 0)).build();
+        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0)).build();
         let addr = server.local_addr();
         tokio::spawn(server.serve());
 
@@ -59,7 +59,7 @@ mod tests {
 
     #[tokio::test]
     async fn uuid_assigned() {
-        let server = SignalingServer::client_server_builder((Ipv4Addr::UNSPECIFIED, 0)).build();
+        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0)).build();
         let addr = server.local_addr();
         tokio::spawn(server.serve());
 
@@ -74,7 +74,7 @@ mod tests {
 
     #[tokio::test]
     async fn new_client() {
-        let server = SignalingServer::client_server_builder((Ipv4Addr::UNSPECIFIED, 0)).build();
+        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0)).build();
         let addr = server.local_addr();
         tokio::spawn(server.serve());
 
@@ -96,7 +96,7 @@ mod tests {
 
     #[tokio::test]
     async fn disconnect_client() {
-        let server = SignalingServer::client_server_builder((Ipv4Addr::UNSPECIFIED, 0)).build();
+        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0)).build();
         let addr = server.local_addr();
         tokio::spawn(server.serve());
 
@@ -124,7 +124,7 @@ mod tests {
 
     #[tokio::test]
     async fn signal() {
-        let server = SignalingServer::client_server_builder((Ipv4Addr::UNSPECIFIED, 0)).build();
+        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0)).build();
         let addr = server.local_addr();
         tokio::spawn(server.serve());
 
@@ -165,7 +165,7 @@ mod tests {
     async fn on_connection_req_callback() {
         let success = Arc::new(AtomicBool::new(false));
 
-        let server = SignalingServer::client_server_builder((Ipv4Addr::UNSPECIFIED, 0))
+        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
             .on_connection_request({
                 let success = success.clone();
                 move |_| {
@@ -188,7 +188,7 @@ mod tests {
         let upgrade_called = Arc::new(AtomicBool::new(false));
         let peer_connected = Arc::new(AtomicBool::new(false));
 
-        let server = SignalingServer::client_server_builder((Ipv4Addr::UNSPECIFIED, 0))
+        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
             .on_connection_request({
                 let upgrade_called = upgrade_called.clone();
                 move |_| {
@@ -216,7 +216,7 @@ mod tests {
     async fn on_id_assignment_callback() {
         let success = Arc::new(AtomicBool::new(false));
 
-        let server = SignalingServer::client_server_builder((Ipv4Addr::UNSPECIFIED, 0))
+        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
             .on_id_assignment({
                 let success = success.clone();
                 move |_| success.store(true, std::sync::atomic::Ordering::Release)
@@ -237,7 +237,7 @@ mod tests {
     async fn on_host_connect_callback() {
         let success = Arc::new(AtomicBool::new(false));
 
-        let server = SignalingServer::client_server_builder((Ipv4Addr::UNSPECIFIED, 0))
+        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
             .on_host_connected({
                 let success = success.clone();
                 move |_| success.store(true, std::sync::atomic::Ordering::Release)
@@ -258,7 +258,7 @@ mod tests {
     async fn on_host_disconnect_callback() {
         let success = Arc::new(AtomicBool::new(false));
 
-        let server = SignalingServer::client_server_builder((Ipv4Addr::UNSPECIFIED, 0))
+        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
             .on_host_disconnected({
                 let success = success.clone();
                 move |_| success.store(true, std::sync::atomic::Ordering::Release)
@@ -282,7 +282,7 @@ mod tests {
     async fn on_client_connect_callback() {
         let success = Arc::new(AtomicBool::new(false));
 
-        let server = SignalingServer::client_server_builder((Ipv4Addr::UNSPECIFIED, 0))
+        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
             .on_client_connected({
                 let success = success.clone();
                 move |_| success.store(true, std::sync::atomic::Ordering::Release)
@@ -310,7 +310,7 @@ mod tests {
     async fn on_client_disconnect_callback() {
         let success = Arc::new(AtomicBool::new(false));
 
-        let server = SignalingServer::client_server_builder((Ipv4Addr::UNSPECIFIED, 0))
+        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
             .on_client_disconnected({
                 let success = success.clone();
                 move |_| success.store(true, std::sync::atomic::Ordering::Release)

--- a/matchbox_signaling/tests/full_mesh.rs
+++ b/matchbox_signaling/tests/full_mesh.rs
@@ -48,7 +48,7 @@ mod tests {
 
     #[tokio::test]
     async fn ws_connect() {
-        let server = SignalingServer::full_mesh_builder((Ipv4Addr::UNSPECIFIED, 0)).build();
+        let server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0)).build();
         let addr = server.local_addr();
         tokio::spawn(server.serve());
 
@@ -59,7 +59,7 @@ mod tests {
 
     #[tokio::test]
     async fn uuid_assigned() {
-        let server = SignalingServer::full_mesh_builder((Ipv4Addr::UNSPECIFIED, 0)).build();
+        let server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0)).build();
         let addr = server.local_addr();
         tokio::spawn(server.serve());
 
@@ -75,7 +75,7 @@ mod tests {
 
     #[tokio::test]
     async fn new_peer() {
-        let server = SignalingServer::full_mesh_builder((Ipv4Addr::UNSPECIFIED, 0)).build();
+        let server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0)).build();
         let addr = server.local_addr();
         tokio::spawn(server.serve());
 
@@ -100,7 +100,7 @@ mod tests {
 
     #[tokio::test]
     async fn disconnect_peer() {
-        let server = SignalingServer::full_mesh_builder((Ipv4Addr::UNSPECIFIED, 0)).build();
+        let server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0)).build();
         let addr = server.local_addr();
         tokio::spawn(server.serve());
 
@@ -131,7 +131,7 @@ mod tests {
 
     #[tokio::test]
     async fn signal() {
-        let server = SignalingServer::full_mesh_builder((Ipv4Addr::UNSPECIFIED, 0)).build();
+        let server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0)).build();
         let addr = server.local_addr();
         tokio::spawn(server.serve());
 
@@ -175,7 +175,7 @@ mod tests {
     async fn on_connection_req_callback() {
         let success = Arc::new(AtomicBool::new(false));
 
-        let server = SignalingServer::client_server_builder((Ipv4Addr::UNSPECIFIED, 0))
+        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
             .on_connection_request({
                 let success = success.clone();
                 move |_| {
@@ -198,7 +198,7 @@ mod tests {
         let upgrade_called = Arc::new(AtomicBool::new(false));
         let peer_connected = Arc::new(AtomicBool::new(false));
 
-        let server = SignalingServer::full_mesh_builder((Ipv4Addr::UNSPECIFIED, 0))
+        let server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0))
             .on_connection_request({
                 let upgrade_called = upgrade_called.clone();
                 move |_| {
@@ -226,7 +226,7 @@ mod tests {
     async fn on_id_assignment_callback() {
         let success = Arc::new(AtomicBool::new(false));
 
-        let server = SignalingServer::full_mesh_builder((Ipv4Addr::UNSPECIFIED, 0))
+        let server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0))
             .on_id_assignment({
                 let success = success.clone();
                 move |_| success.store(true, std::sync::atomic::Ordering::Release)
@@ -247,7 +247,7 @@ mod tests {
     async fn on_connect_callback() {
         let success = Arc::new(AtomicBool::new(false));
 
-        let server = SignalingServer::full_mesh_builder((Ipv4Addr::UNSPECIFIED, 0))
+        let server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0))
             .on_peer_connected({
                 let success = success.clone();
                 move |_| success.store(true, std::sync::atomic::Ordering::Release)
@@ -268,7 +268,7 @@ mod tests {
     async fn on_disconnect_callback() {
         let success = Arc::new(AtomicBool::new(false));
 
-        let server = SignalingServer::full_mesh_builder((Ipv4Addr::UNSPECIFIED, 0))
+        let server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0))
             .on_peer_disconnected({
                 let success = success.clone();
                 move |_| success.store(true, std::sync::atomic::Ordering::Release)


### PR DESCRIPTION
I'm not really sure what the deal is, but when running the tests, I get panics from every signaling test, unless I only bind to localhost...

```
---- signaling::tests::signal stdout ----
thread 'signaling::tests::signal' panicked at 'called `Result::unwrap()` on an `Err` value: Io(Os { code: 10049, kind: AddrNotAvailable, message: "The requested address is not valid in its context." })', matchbox_server\src\signaling.rs:394:18
```

However, I *don't* get this error in the examples. Maybe something is off in my windows firewall settings. Do the tests run on windows for either of you?