### PR TITLE
bevy_matchbox: don't use commands

### DIFF
--- a/bevy_matchbox/src/lib.rs
+++ b/bevy_matchbox/src/lib.rs
@@ -2,14 +2,9 @@
 #![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)]
 
-use bevy::{
-    ecs::system::Command,
-    prelude::{Commands, Deref, DerefMut, Resource, World},
-    tasks::IoTaskPool,
-};
+use bevy::{prelude::*, tasks::IoTaskPool};
 pub use matchbox_socket;
 use matchbox_socket::{BuildablePlurality, WebRtcSocket, WebRtcSocketBuilder};
-use std::marker::PhantomData;
 
 /// A [`Resource`] wrapping [`WebRtcSocket`].
 ///
@@ -18,65 +13,25 @@ use std::marker::PhantomData;
 /// # use bevy::prelude::*;
 /// # fn system(mut commands: Commands) {
 /// let room_url = "ws://matchbox.example.com";
-/// commands.open_socket(WebRtcSocketBuilder::new(room_url).add_channel(ChannelConfig::reliable()));
-/// commands.close_socket::<SingleChannel>();
+/// let builder = WebRtcSocketBuilder::new(room_url).add_channel(ChannelConfig::reliable());
+/// let socket = MatchboxSocket::<SingleChannel>::from(builder);
+/// commands.insert_resource(socket);
 /// # }
 /// ```
-///
-/// To create and destroy this resource use the [`OpenSocket`] and [`CloseSocket`] [`Command`]s respectively.
-#[derive(Resource, Debug, Deref, DerefMut)]
+#[derive(Resource, Component, Debug, Deref, DerefMut)]
 pub struct MatchboxSocket<C: BuildablePlurality>(WebRtcSocket<C>);
 
-/// A [`Command`] used to open a [`MatchboxSocket`] and allocate it as a resource.
-struct OpenSocket<C: BuildablePlurality>(WebRtcSocketBuilder<C>);
-
-impl<C: BuildablePlurality + 'static> Command for OpenSocket<C> {
-    fn write(self, world: &mut World) {
-        let (socket, message_loop) = self.0.build();
-
-        let task_pool = IoTaskPool::get();
-        task_pool.spawn(message_loop).detach();
-
-        world.insert_resource(MatchboxSocket(socket));
-    }
-}
-
-/// A [`Commands`] extension used to open a [`MatchboxSocket`] and allocate it as a resource.
-pub trait OpenSocketExt<C: BuildablePlurality> {
-    /// Opens a [`MatchboxSocket`] and allocates it as a resource.
-    fn open_socket(&mut self, socket_builder: WebRtcSocketBuilder<C>);
-}
-
-impl<'w, 's, C: BuildablePlurality + 'static> OpenSocketExt<C> for Commands<'w, 's> {
-    fn open_socket(&mut self, socket_builder: WebRtcSocketBuilder<C>) {
-        self.add(OpenSocket(socket_builder))
-    }
-}
-
-/// A [`Command`] used to close a [`WebRtcSocket`], deleting the [`MatchboxSocket`] resource.
-struct CloseSocket<C: BuildablePlurality>(PhantomData<C>);
-
-impl<C: BuildablePlurality + 'static> Command for CloseSocket<C> {
-    fn write(self, world: &mut World) {
-        world.remove_resource::<MatchboxSocket<C>>();
-    }
-}
-
-/// A [`Commands`] extension used to close a [`WebRtcSocket`], deleting the [`MatchboxSocket`] resource.
-pub trait CloseSocketExt {
-    /// Delete the [`MatchboxSocket`] resource.
-    fn close_socket<C: BuildablePlurality + 'static>(&mut self);
-}
-
-impl<'w, 's> CloseSocketExt for Commands<'w, 's> {
-    fn close_socket<C: BuildablePlurality + 'static>(&mut self) {
-        self.add(CloseSocket::<C>(PhantomData::default()))
+impl<C: BuildablePlurality> From<WebRtcSocketBuilder<C>> for MatchboxSocket<C> {
+    fn from(value: WebRtcSocketBuilder<C>) -> Self {
+        let (socket, fut) = value.build();
+        IoTaskPool::get().spawn(fut).detach();
+        Self(socket)
     }
 }
 
 /// use `bevy_matchbox::prelude::*;` to import common resources and commands
 pub mod prelude {
-    pub use crate::{CloseSocketExt, MatchboxSocket, OpenSocketExt};
+    pub use crate::MatchboxSocket;
     pub use matchbox_socket::{
         ChannelConfig, MultipleChannels, PeerId, PeerState, SingleChannel, WebRtcSocketBuilder,
     };

--- a/examples/bevy_ggrs/src/main.rs
+++ b/examples/bevy_ggrs/src/main.rs
@@ -89,7 +89,9 @@ fn start_matchbox_socket(mut commands: Commands, args: Res<Args>) {
     let room_url = format!("{}/{}", &args.matchbox, room_id);
     info!("connecting to matchbox server: {:?}", room_url);
 
-    commands.open_socket(WebRtcSocketBuilder::new(room_url).add_channel(ChannelConfig::ggrs()));
+    let socket_builder = WebRtcSocketBuilder::new(room_url).add_channel(ChannelConfig::ggrs());
+    let socket = MatchboxSocket::<SingleChannel>::from(socket_builder);
+    commands.insert_resource(socket);
 }
 
 // Marker components for UI


### PR DESCRIPTION
I'm wondering if the commands are a little bit too much magic.

Trying out a more explicit API.

I think it's a little bit more flexible, and a little bit easier to understand whats happening (add a resource before you can use it).