### PR TITLE
Fix panic when signal is received after handshake was completed

### DIFF
--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -188,12 +188,9 @@ async fn message_loop<M: Messenger>(
                                 from_peer_tx
                             });
 
-                            if signal_tx.is_closed() {
-                                warn!("ignoring signal from peer {:?} because the handshake is already finished", sender);
-                                continue;
+                            if signal_tx.unbounded_send(data).is_err() {
+                                warn!("ignoring signal from peer {sender:?} because the handshake has already finished");
                             }
-
-                            signal_tx.unbounded_send(data).expect("failed to forward signal to handshaker");
                         },
                     }
                 }


### PR DESCRIPTION
A straightforward fix for the issue with handshake channels being closed while receiving the signal.

Fixes #183 