### PR TITLE
Release `matchbox_socket` v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "matchbox_socket"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-compat",
  "async-trait",

--- a/matchbox_socket/Cargo.toml
+++ b/matchbox_socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matchbox_socket"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Johan Helsing <johanhelsing@gmail.com>"]
 description = "Painless WebRTC peer-to-peer full-mesh networking socket"
 edition = "2021"


### PR DESCRIPTION
We had a pretty bad regression in #183, and one accidentally private error type, and a missing feature dependency in `ggrs` on wasm.

Let's do a point release for `matchbox_socket` only.

Otherwise, it should be just doc/ci changes (see https://github.com/johanhelsing/matchbox/compare/v0.6.0...release-0.6.1).

