### PR TITLE
Add missing `ggrs/wasm-bindgen` dependency for `ggrs` feature

### DIFF
--- a/matchbox_socket/Cargo.toml
+++ b/matchbox_socket/Cargo.toml
@@ -41,11 +41,13 @@ once_cell = { version = "1.17", default-features = false, features = [
 ] }
 crossbeam-channel = "0.5"
 
-# ggrs-socket
 ggrs = { version = "0.9.3", default-features = false, optional = true }
 bincode = { version = "1.3", default-features = false, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+ggrs = { version = "0.9.3", default-features = false, optional = true, features = [
+  "wasm-bindgen",
+] }
 ws_stream_wasm = { version = "0.7", default-features = false }
 wasm-bindgen-futures = { version = "0.4", default-features = false }
 wasm-bindgen = { version = "0.2", default-features = false, features = [


### PR DESCRIPTION
Fixes a build error when building for wasm with the `ggrs` feature.