### PR TITLE
Add lavagna to Showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Projects using Matchbox:
 - [Extreme Bevy](https://helsing.studio/extreme) - Simple 2-player arcade shooter
 - [Matchbox demo](https://helsing.studio/box_game/)
 - [A Janitors Nightmare](https://gorktheork.itch.io/bevy-jam-1-submission) - 2-player jam game
+- [Lavagna](https://github.com/alepez/lavagna) - collaborative blackboard for online meetings
 
 ## Contributing
 


### PR DESCRIPTION
I've recently released lavagna, a collaborative blackboard. I loved how easy it was integrating WebRTC on my project with matchbox. Many thanks! I feel `lavagna` can be under the *Showcase* section of matchbox README.