### PR TITLE
`WebRtcConnection.update_peers()` error handling.

### DIFF
--- a/matchbox_socket/src/lib.rs
+++ b/matchbox_socket/src/lib.rs
@@ -10,7 +10,7 @@ mod webrtc_socket;
 pub use error::Error;
 pub use matchbox_protocol::PeerId;
 pub use webrtc_socket::{
-    error::GetChannelError, BuildablePlurality, ChannelConfig, ChannelPlurality, MessageLoopFuture,
+    error::ChannelError, BuildablePlurality, ChannelConfig, ChannelPlurality, MessageLoopFuture,
     MultipleChannels, NoChannels, Packet, PeerState, RtcIceServerConfig, SingleChannel,
     WebRtcChannel, WebRtcSocket, WebRtcSocketBuilder,
 };

--- a/matchbox_socket/src/webrtc_socket/error.rs
+++ b/matchbox_socket/src/webrtc_socket/error.rs
@@ -14,8 +14,10 @@ pub enum ChannelError {
     #[error("This channel has already been taken and is no longer on the socket")]
     Taken,
     /// Channel might have been opened but later closed, or never opened in the first place.
-    #[error("This channel is broken.")]
-    Broken,
+    /// The latter can for example occur when an one calls `try_update_peers` on a socket that was
+    /// given an invalid room URL.
+    #[error("This channel is closed.")]
+    Closed,
 }
 
 /// An error that can occur with WebRTC signaling.

--- a/matchbox_socket/src/webrtc_socket/error.rs
+++ b/matchbox_socket/src/webrtc_socket/error.rs
@@ -3,9 +3,9 @@ use cfg_if::cfg_if;
 use futures_channel::mpsc::TrySendError;
 
 /// An error that can occur when getting a socket's channel through
-/// `get_channel` or `take_channel`.
+/// `get_channel`, `take_channel` or `try_update_peers`.
 #[derive(Debug, thiserror::Error)]
-pub enum GetChannelError {
+pub enum ChannelError {
     /// Can occur if trying to get a channel with an Id that was not added while building the
     /// socket
     #[error("This channel was never created")]
@@ -13,6 +13,9 @@ pub enum GetChannelError {
     /// The channel has already been taken and is no longer on the socket
     #[error("This channel has already been taken and is no longer on the socket")]
     Taken,
+    /// Channel might have been opened but later closed, or never opened in the first place.
+    #[error("This channel is broken.")]
+    Broken,
 }
 
 /// An error that can occur with WebRTC signaling.

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -419,7 +419,7 @@ impl<C: ChannelPlurality> WebRtcSocket<C> {
     ///
     /// # Panics
     ///
-    /// Will panic if the socket is broken.
+    /// Will panic if the socket is closed.
     ///
     /// [`WebRtcSocket::try_update_peers`] is the equivalent method that will instead return a
     /// `Result`.
@@ -428,7 +428,7 @@ impl<C: ChannelPlurality> WebRtcSocket<C> {
     }
 
     /// Similar to [`WebRtcSocket::update_peers`]. Will instead return a Result::Err if the
-    /// socket is broken.
+    /// socket is closed.
     pub fn try_update_peers(&mut self) -> Result<Vec<(PeerId, PeerState)>, ChannelError> {
         let mut changes = Vec::new();
         while let Ok(res) = self.peer_state_rx.try_next() {
@@ -439,7 +439,7 @@ impl<C: ChannelPlurality> WebRtcSocket<C> {
                         changes.push((id, state));
                     }
                 }
-                None => return Err(ChannelError::Broken),
+                None => return Err(ChannelError::Closed),
             }
         }
 

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -419,7 +419,7 @@ impl<C: ChannelPlurality> WebRtcSocket<C> {
     ///
     /// # Panics
     ///
-    /// Will panic if the channel has been closed or is broken.
+    /// Will panic if the socket has been closed or is broken.
     ///
     /// [`WebRtcSocket::try_update_peers`] is the equivalent method that will instead return a
     /// `Result`.
@@ -428,7 +428,7 @@ impl<C: ChannelPlurality> WebRtcSocket<C> {
     }
 
     /// Similar to [`WebRtcSocket::update_peers`]. Will instead return a Result::Err if the
-    /// channel is closed or broken.
+    /// socket is closed or broken.
     pub fn try_update_peers(&mut self) -> Result<Vec<(PeerId, PeerState)>, &'static str> {
         let mut changes = Vec::new();
         while let Ok(res) = self.peer_state_rx.try_next() {

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -427,6 +427,23 @@ impl<C: ChannelPlurality> WebRtcSocket<C> {
         changes
     }
 
+    pub fn try_update_peers(&mut self) -> Result<Vec<(PeerId, PeerState)>, &'static str> {
+        let mut changes = Vec::new();
+        while let Ok(res) = self.peer_state_rx.try_next() {
+            match res {
+                Some((id, state)) => {
+                    let old = self.peers.insert(id, state);
+                    if old != Some(state) {
+                        changes.push((id, state));
+                    }
+                }
+                None => return Err("Channel closed"),
+            }
+        }
+
+        Ok(changes)
+    }
+
     /// Returns an iterator of the ids of the connected peers.
     ///
     /// Note: You have to call [`WebRtcSocket::update_peers`] for this list to be accurate.

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -419,7 +419,7 @@ impl<C: ChannelPlurality> WebRtcSocket<C> {
     ///
     /// # Panics
     ///
-    /// Will panic if the socket is closed.
+    /// Will panic if the socket future has been dropped.
     ///
     /// [`WebRtcSocket::try_update_peers`] is the equivalent method that will instead return a
     /// `Result`.

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -424,19 +424,7 @@ impl<C: ChannelPlurality> WebRtcSocket<C> {
     /// [`WebRtcSocket::try_update_peers`] is the equivalent method that will instead return a
     /// `Result`.
     pub fn update_peers(&mut self) -> Vec<(PeerId, PeerState)> {
-        let mut changes = Vec::new();
-        while let Ok(res) = self.peer_state_rx.try_next() {
-            match res {
-                Some((id, state)) => {
-                    let old = self.peers.insert(id, state);
-                    if old != Some(state) {
-                        changes.push((id, state));
-                    }
-                }
-                None => panic!("Channel closed."),
-            }
-        }
-        changes
+        self.try_update_peers().unwrap()
     }
 
     pub fn try_update_peers(&mut self) -> Result<Vec<(PeerId, PeerState)>, &'static str> {

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -419,7 +419,7 @@ impl<C: ChannelPlurality> WebRtcSocket<C> {
     ///
     /// # Panics
     ///
-    /// Will panic if the connection has been closed or is broken.
+    /// Will panic if the channel has been closed or is broken.
     ///
     /// [`WebRtcSocket::try_update_peers`] is the equivalent method that will instead return a
     /// `Result`.
@@ -427,6 +427,8 @@ impl<C: ChannelPlurality> WebRtcSocket<C> {
         self.try_update_peers().unwrap()
     }
 
+    /// Similar to [`WebRtcSocket::update_peers`]. Will instead return a Result::Err if the
+    /// channel is closed or broken.
     pub fn try_update_peers(&mut self) -> Result<Vec<(PeerId, PeerState)>, &'static str> {
         let mut changes = Vec::new();
         while let Ok(res) = self.peer_state_rx.try_next() {


### PR DESCRIPTION
A simplified example of what I was trying to achieve that illustrates the issue at hand.

```rust
    loop {
        // Something that calls `WebRtcSocket.update_peers()` in the background.
        connection.register_peers();

        if connection.connected_peers_count() == 0 {
            info!("Waiting for a connection.");
            futures_timer::Delay::new(Duration::from_millis(500)).await;
            continue;
        }

        connection.send(...);
    }
```

At glance this look fine, but this snippet will cause an infinite loop if the connection is broken. This is because `WebRtcSocket.update_peers()` silently "fails" when that is the case.

This draft implements a `try_update_peers()` that simply returns a `Result<Vec<(PeerId, PeerState)>, &'static str>`, where the static is  "Channel closed".

I haven't yet added any documentation nor tests, as several error handling questions remain unanswered. 

Some of which are:

* Should the function return a custom return type?
* Should we start by letting `update_peers()` panic, as is done with `send()` and `recieve()`?
* Or should we just wait with changing the error handling of `update_peers()` until some kind of error handling policy has been decided? (I.e. in https://github.com/johanhelsing/matchbox/issues/91)

Come to think of it, I'm mostly in favor of letting `update_peers()` panic for now, with it being documented of course. It would be a minimal API change that does the job. But I'm more than happy to take suggestions from the maintainers 😊
