### PR TITLE
Fix broken matchbox_server docker image

### DIFF
--- a/matchbox_server/Dockerfile
+++ b/matchbox_server/Dockerfile
@@ -17,7 +17,7 @@ COPY matchbox_signaling /usr/src/matchbox_signaling
 
 RUN cargo build --release
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 RUN apt-get update && apt-get install -y libssl1.1
 RUN rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/src/matchbox_server/target/release/matchbox_server /usr/local/bin/matchbox_server


### PR DESCRIPTION
It had errors with missing glibc on launch