### PR TITLE
Add more information to error messages

### DIFF
--- a/matchbox_signaling/src/error.rs
+++ b/matchbox_signaling/src/error.rs
@@ -4,10 +4,10 @@ use crate::signaling_server::error::SignalingError;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// An error occurring during the signaling loop.
-    #[error("An unrecoverable error in the signaling loop")]
+    #[error("An unrecoverable error in the signaling loop: {0}")]
     Signaling(#[from] SignalingError),
 
     /// An error occurring from hyper
-    #[error("Hyper error")]
+    #[error("Hyper error: {0}")]
     Hyper(#[from] hyper::Error),
 }

--- a/matchbox_signaling/src/signaling_server/error.rs
+++ b/matchbox_signaling/src/signaling_server/error.rs
@@ -5,19 +5,19 @@ use tokio::sync::mpsc::error::SendError;
 #[derive(Debug, thiserror::Error)]
 pub enum ClientRequestError {
     /// An error originating from Axum
-    #[error("Axum error")]
+    #[error("Axum error: {0}")]
     Axum(#[from] axum::Error),
 
     /// The socket is closed
-    #[error("Message is close")]
+    #[error("Socket is closed.")]
     Close,
 
     /// Message received was not JSON
-    #[error("Json error")]
+    #[error("Json error: {0}")]
     Json(#[from] serde_json::Error),
 
     /// Unsupported message type (not JSON)
-    #[error("Unsupported message type")]
+    #[error("Unsupported message type: {0:?}")]
     UnsupportedType(Message),
 }
 
@@ -29,6 +29,6 @@ pub enum SignalingError {
     UnknownPeer,
 
     /// The message was undeliverable (socket may be closed or a future was dropped prematurely)
-    #[error("Undeliverable message")]
+    #[error("Undeliverable message: {0}")]
     Undeliverable(#[from] SendError<Result<Message, axum::Error>>),
 }

--- a/matchbox_socket/src/error.rs
+++ b/matchbox_socket/src/error.rs
@@ -4,6 +4,6 @@ use crate::webrtc_socket::error::SignalingError;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// An error occurring during the signaling loop.
-    #[error("An error in the signaling loop")]
+    #[error("An error in the signaling loop: {0}")]
     Signaling(#[from] SignalingError),
 }

--- a/matchbox_socket/src/webrtc_socket/error.rs
+++ b/matchbox_socket/src/webrtc_socket/error.rs
@@ -24,18 +24,18 @@ pub enum ChannelError {
 #[derive(Debug, thiserror::Error)]
 pub enum SignalingError {
     // Common
-    #[error("failed to send event to signaling server")]
+    #[error("failed to send event to signaling server: {0}")]
     Undeliverable(#[from] TrySendError<PeerEvent>),
     #[error("The stream is exhausted")]
     StreamExhausted,
     #[error("Message received in unknown format")]
     UnknownFormat,
-    #[error("failed to establish initial connection")]
+    #[error("failed to establish initial connection: {0}")]
     ConnectionFailed(#[from] Box<SignalingError>),
 
     // Native
     #[cfg(not(target_arch = "wasm32"))]
-    #[error("socket failure communicating with signaling server")]
+    #[error("socket failure communicating with signaling server: {0}")]
     Socket(#[from] async_tungstenite::tungstenite::Error),
 
     // WASM
@@ -47,12 +47,12 @@ pub enum SignalingError {
 /// An error that can occur with WebRTC messaging.
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, thiserror::Error)]
-#[error("failed to send message to peer")]
+#[error("failed to send message to peer: {0}")]
 pub(crate) struct MessagingError(#[from] futures_channel::mpsc::TrySendError<crate::Packet>);
 
 #[cfg(target_arch = "wasm32")]
 #[derive(Debug, thiserror::Error)]
-#[error("failed to send message to peer")]
+#[error("failed to send message to peer: {0}")]
 pub(crate) struct MessagingError(#[from] JsError);
 
 cfg_if! {

--- a/matchbox_socket/src/webrtc_socket/error.rs
+++ b/matchbox_socket/src/webrtc_socket/error.rs
@@ -40,7 +40,7 @@ pub enum SignalingError {
 
     // WASM
     #[cfg(target_arch = "wasm32")]
-    #[error("socket failure communicating with signaling server")]
+    #[error("socket failure communicating with signaling server: {0}")]
     Socket(#[from] ws_stream_wasm::WsErr),
 }
 


### PR DESCRIPTION
The error types defined using `#[derive(thiserror::Error)]` do not include the error message from any inner wrapped errors, which makes it very difficult to debug any errors that occur while using this crate.

This PR simply changes the macro-generated error messages to include the inner errors.