### PR TITLE
Add missing RTCIceCredentialType to the RTCIceServer

### DIFF
--- a/matchbox_socket/src/webrtc_socket/native.rs
+++ b/matchbox_socket/src/webrtc_socket/native.rs
@@ -436,8 +436,8 @@ async fn create_rtc_peer_connection(
             // other hand, will error if credential is present and
             // `credential_type` is `Unspecified` So while our pubic API mirrors
             // the web spec/MDN with non-standard fields removed (no
-            // credential_type), here we set the type to `Password`, so
-            // if, and only if there is a `credential`, so webrtc-rs cooperates.
+            // credential_type), here we set the type to `Password` if and only
+            // if there is a `credential`, so webrtc-rs cooperates.
             //
             // In the future if webrtc-rs follows the spec more closely, this
             // workaround can be removed.

--- a/matchbox_socket/src/webrtc_socket/native.rs
+++ b/matchbox_socket/src/webrtc_socket/native.rs
@@ -33,6 +33,7 @@ use webrtc::{
     data_channel::{data_channel_init::RTCDataChannelInit, RTCDataChannel},
     ice_transport::{
         ice_candidate::{RTCIceCandidate, RTCIceCandidateInit},
+        ice_credential_type::RTCIceCredentialType,
         ice_server::RTCIceServer,
     },
     peer_connection::{
@@ -427,7 +428,7 @@ async fn create_rtc_peer_connection(
             urls: ice_server_config.urls.clone(),
             username: ice_server_config.username.clone().unwrap_or_default(),
             credential: ice_server_config.credential.clone().unwrap_or_default(),
-            ..Default::default()
+            credential_type: RTCIceCredentialType::Password,
         }],
         ..Default::default()
     };

--- a/matchbox_socket/src/webrtc_socket/native.rs
+++ b/matchbox_socket/src/webrtc_socket/native.rs
@@ -428,7 +428,12 @@ async fn create_rtc_peer_connection(
             urls: ice_server_config.urls.clone(),
             username: ice_server_config.username.clone().unwrap_or_default(),
             credential: ice_server_config.credential.clone().unwrap_or_default(),
-            credential_type: RTCIceCredentialType::Password,
+            credential_type: ice_server_config
+                .credential
+                .as_ref()
+                .map_or(RTCIceCredentialType::Unspecified, |_| {
+                    RTCIceCredentialType::Password
+                }),
         }],
         ..Default::default()
     };


### PR DESCRIPTION
Problem:
The default RTCIceCredentialType [is `Unspecified`](https://github.com/webrtc-rs/webrtc/blob/master/webrtc/src/ice_transport/ice_credential_type.rs#L9-L10) and that will eventually end up crashing when [used here](https://github.com/johanhelsing/matchbox/blob/main/matchbox_socket/src/webrtc_socket/native.rs#L124-L126) because the return value will be Err since [this](https://github.com/webrtc-rs/webrtc/blob/71157ba2153a891a8cfd819f3cf1441a7a0808d8/webrtc/src/ice_transport/ice_server.rs#L52)

This PR will default to `RTCIceCredentialType::Password`. I don't know if that's what you would prefer, but it fixes my problem :)