### PR TITLE
Don't log null ice candidates as errors on native

### DIFF
--- a/matchbox_socket/src/webrtc_socket/native.rs
+++ b/matchbox_socket/src/webrtc_socket/native.rs
@@ -396,10 +396,15 @@ impl CandidateTrickle {
                     debug!("received ice candidate: {candidate_json:?}");
                     match serde_json::from_str::<RTCIceCandidateInit>(&candidate_json) {
                         Ok(candidate_init) => {
+                            debug!("ice candidate received: {}", candidate_init.candidate);
                             peer_connection.add_ice_candidate(candidate_init).await?;
                         }
                         Err(err) => {
-                            error!("failed to parse ice candidate json, ignoring: {err:?}");
+                            if *candidate_json == *"null" {
+                                debug!("Received null ice candidate, this means there are no further ice candidates");
+                            } else {
+                                warn!("failed to parse ice candidate json, ignoring: {err:?}");
+                            }
                         }
                     }
                 }

--- a/matchbox_socket/src/webrtc_socket/wasm.rs
+++ b/matchbox_socket/src/webrtc_socket/wasm.rs
@@ -346,7 +346,6 @@ async fn complete_handshake(
             }
             msg = peer_signal_rx.next() => {
                 if let Some(PeerSignal::IceCandidate(candidate)) = msg {
-                    debug!("received ice candidate: {candidate:?}");
                     try_add_rtc_ice_candidate(&conn, &candidate).await;
                 }
             }
@@ -375,7 +374,7 @@ async fn try_add_rtc_ice_candidate(connection: &RtcPeerConnection, candidate_str
     let parsed_candidate = match js_sys::JSON::parse(candidate_string) {
         Ok(c) => c,
         Err(err) => {
-            error!("failed to parse candidate json: {err:?}");
+            warn!("failed to parse ice candidate json, ignoring: {err:?}");
             return;
         }
     };
@@ -384,7 +383,9 @@ async fn try_add_rtc_ice_candidate(connection: &RtcPeerConnection, candidate_str
         debug!("Received null ice candidate, this means there are no further ice candidates");
         None
     } else {
-        Some(RtcIceCandidateInit::from(parsed_candidate))
+        let candidate = RtcIceCandidateInit::from(parsed_candidate);
+        debug!("ice candidate received: {candidate:?}");
+        Some(candidate)
     };
 
     JsFuture::from(


### PR DESCRIPTION
Closes #280 

The root cause of the issue is, when a native client receives ICE candidates from a WASM client, a "null" is sent as the terminating signal to delineate the end of candidates.

This is expected behavior, but is logged as an error for native.

This ensures the same behavior exists on web/native.