### PR TITLE
Use webgl for bevy_ggrs example

### DIFF
--- a/examples/bevy_ggrs/Cargo.toml
+++ b/examples/bevy_ggrs/Cargo.toml
@@ -30,6 +30,7 @@ bevy = { version = "0.11", default-features = false, features = [
   "bevy_asset",
   "bevy_sprite",
   "png",
+  "webgl2",
   # gh actions runners don't like wayland
   "x11",
 ] }


### PR DESCRIPTION
We switched to webgpu by accident when upgrading to Bevy 0.11.

In Bevy 0.11 webgl2 is still default, but not when disabling default features.

It's not working properly everywhere yet, so switch back to webgl2, at least until it's default in bevy.