### PR TITLE
Fix GLIB version not match in ARM

### DIFF
--- a/matchbox_server/Dockerfile
+++ b/matchbox_server/Dockerfile
@@ -3,7 +3,7 @@
 # to build, run `docker build -f matchbox_server/Dockerfile` from root of the
 # repository
 
-FROM rust:1.72 as builder
+FROM rust:1.72-slim-bullseye as builder
 
 WORKDIR /usr/src/matchbox_server/
 


### PR DESCRIPTION
Current dockerfile cannot run on ARM because builder use different GLIB version with runner 
This commit change builder to the same tag as runner