### PR TITLE
Fix panic when using bevy_matchbox signaling feature

### DIFF
--- a/bevy_matchbox/Cargo.toml
+++ b/bevy_matchbox/Cargo.toml
@@ -21,7 +21,7 @@ readme = "../README.md"
 
 [features]
 ggrs = ["matchbox_socket/ggrs"]
-signaling = ["matchbox_signaling"]
+signaling = ["dep:matchbox_signaling", "dep:async-compat"]
 
 [dependencies]
 bevy = { version = "0.11", default-features = false }
@@ -30,3 +30,4 @@ cfg-if = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 matchbox_signaling = { version = "0.7", path = "../matchbox_signaling", optional = true }
+async-compat = { version = "0.2", optional = true }

--- a/bevy_matchbox/src/signaling.rs
+++ b/bevy_matchbox/src/signaling.rs
@@ -1,5 +1,4 @@
-use std::net::SocketAddr;
-
+use async_compat::CompatExt;
 use bevy::{
     ecs::system::Command,
     prelude::{Commands, Resource},
@@ -14,6 +13,7 @@ use matchbox_signaling::{
     },
     Error, SignalingCallbacks, SignalingServer, SignalingServerBuilder, SignalingState,
 };
+use std::net::SocketAddr;
 
 /// A [`SignalingServer`] as a [`Resource`].
 ///
@@ -80,7 +80,7 @@ where
 impl From<SignalingServer> for MatchboxServer {
     fn from(server: SignalingServer) -> Self {
         let task_pool = IoTaskPool::get();
-        let task = task_pool.spawn(server.serve());
+        let task = task_pool.spawn(server.serve().compat());
         MatchboxServer(task)
     }
 }

--- a/matchbox_signaling/src/signaling_server/builder.rs
+++ b/matchbox_signaling/src/signaling_server/builder.rs
@@ -130,14 +130,12 @@ where
             .layer(Extension(self.shared_callbacks))
             .layer(Extension(self.callbacks))
             .layer(Extension(self.state));
-        let server = axum::Server::bind(&self.socket_addr).serve(
-            self.router
-                .into_make_service_with_connect_info::<SocketAddr>(),
-        );
-        let socket_addr = server.local_addr();
-        SignalingServer {
-            server,
-            socket_addr,
-        }
+
+        let info = self
+            .router
+            .into_make_service_with_connect_info::<SocketAddr>();
+
+        let socket_addr = self.socket_addr;
+        SignalingServer { info, socket_addr }
     }
 }


### PR DESCRIPTION
This moves the binding to the async serve method, not sure if that's a good idea or not.

Fixes: #350 