### PR TITLE
Fix bevy matchbox signaling panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,6 +937,7 @@ dependencies = [
 name = "bevy_matchbox"
 version = "0.7.0"
 dependencies = [
+ "async-compat",
  "bevy",
  "cfg-if",
  "matchbox_signaling",

--- a/bevy_matchbox/Cargo.toml
+++ b/bevy_matchbox/Cargo.toml
@@ -21,7 +21,7 @@ readme = "../README.md"
 
 [features]
 ggrs = ["matchbox_socket/ggrs"]
-signaling = ["matchbox_signaling"]
+signaling = ["dep:matchbox_signaling", "dep:async-compat"]
 
 [dependencies]
 bevy = { version = "0.11", default-features = false }
@@ -30,3 +30,4 @@ cfg-if = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 matchbox_signaling = { version = "0.7", path = "../matchbox_signaling", optional = true }
+async-compat = { version = "0.2", optional = true }

--- a/bevy_matchbox/src/signaling.rs
+++ b/bevy_matchbox/src/signaling.rs
@@ -179,7 +179,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     // https://github.com/johanhelsing/matchbox/issues/350
     fn start_signaling_without_panics() {
         let mut app = App::new();

--- a/bevy_matchbox/src/signaling.rs
+++ b/bevy_matchbox/src/signaling.rs
@@ -187,7 +187,5 @@ mod tests {
             .add_systems(Startup, start_signaling);
 
         app.update();
-
-        assert_eq!(0, 1);
     }
 }

--- a/bevy_matchbox/src/signaling.rs
+++ b/bevy_matchbox/src/signaling.rs
@@ -1,5 +1,4 @@
-use std::net::SocketAddr;
-
+use async_compat::CompatExt;
 use bevy::{
     ecs::system::Command,
     prelude::{Commands, Resource},
@@ -14,6 +13,7 @@ use matchbox_signaling::{
     },
     Error, SignalingCallbacks, SignalingServer, SignalingServerBuilder, SignalingState,
 };
+use std::net::SocketAddr;
 
 /// A [`SignalingServer`] as a [`Resource`].
 ///
@@ -80,7 +80,7 @@ where
 impl From<SignalingServer> for MatchboxServer {
     fn from(server: SignalingServer) -> Self {
         let task_pool = IoTaskPool::get();
-        let task = task_pool.spawn(server.serve());
+        let task = task_pool.spawn(server.serve().compat());
         MatchboxServer(task)
     }
 }

--- a/matchbox_server/src/topology.rs
+++ b/matchbox_server/src/topology.rs
@@ -174,8 +174,8 @@ mod tests {
 
     #[tokio::test]
     async fn ws_connect() {
-        let server = app();
-        let addr = server.local_addr();
+        let mut server = app();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
@@ -185,8 +185,8 @@ mod tests {
 
     #[tokio::test]
     async fn uuid_assigned() {
-        let server = app();
-        let addr = server.local_addr();
+        let mut server = app();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         let (mut client, _response) =
@@ -201,8 +201,8 @@ mod tests {
 
     #[tokio::test]
     async fn new_peer() {
-        let server = app();
-        let addr = server.local_addr();
+        let mut server = app();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         let (mut client_a, _response) =
@@ -226,8 +226,8 @@ mod tests {
 
     #[tokio::test]
     async fn disconnect_peer() {
-        let server = app();
-        let addr = server.local_addr();
+        let mut server = app();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         let (mut client_a, _response) =
@@ -257,8 +257,8 @@ mod tests {
 
     #[tokio::test]
     async fn signal() {
-        let server = app();
-        let addr = server.local_addr();
+        let mut server = app();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         let (mut client_a, _response) =
@@ -299,8 +299,8 @@ mod tests {
 
     #[tokio::test]
     async fn match_pairs() {
-        let server = app();
-        let addr = server.local_addr();
+        let mut server = app();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         let (mut client_a, _response) =
@@ -350,8 +350,8 @@ mod tests {
     }
     #[tokio::test]
     async fn match_pair_and_other_alone_room_without_next() {
-        let server = app();
-        let addr = server.local_addr();
+        let mut server = app();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         let (mut client_a, _response) =
@@ -392,8 +392,8 @@ mod tests {
 
     #[tokio::test]
     async fn match_different_id_same_next() {
-        let server = app();
-        let addr = server.local_addr();
+        let mut server = app();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         let (mut client_a, _response) =
@@ -443,8 +443,8 @@ mod tests {
     }
     #[tokio::test]
     async fn match_same_id_different_next() {
-        let server = app();
-        let addr = server.local_addr();
+        let mut server = app();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         let (mut client_a, _response) =

--- a/matchbox_signaling/src/error.rs
+++ b/matchbox_signaling/src/error.rs
@@ -10,4 +10,8 @@ pub enum Error {
     /// An error occurring from hyper
     #[error("Hyper error: {0}")]
     Hyper(#[from] hyper::Error),
+
+    /// Couldn't bind to socket
+    #[error("Bind error: {0}")]
+    Bind(hyper::Error),
 }

--- a/matchbox_signaling/src/signaling_server/builder.rs
+++ b/matchbox_signaling/src/signaling_server/builder.rs
@@ -115,9 +115,6 @@ where
     }
 
     /// Create a [`SignalingServer`].
-    ///
-    /// # Panics
-    /// This method will panic if the socket address requested cannot be bound.
     pub fn build(mut self) -> SignalingServer {
         // Insert topology
         let state_machine: SignalingStateMachine<Cb, S> =
@@ -136,6 +133,10 @@ where
             .into_make_service_with_connect_info::<SocketAddr>();
 
         let socket_addr = self.socket_addr;
-        SignalingServer { info, socket_addr }
+        SignalingServer {
+            info,
+            requested_addr: socket_addr,
+            server: None,
+        }
     }
 }

--- a/matchbox_signaling/src/signaling_server/builder.rs
+++ b/matchbox_signaling/src/signaling_server/builder.rs
@@ -130,14 +130,12 @@ where
             .layer(Extension(self.shared_callbacks))
             .layer(Extension(self.callbacks))
             .layer(Extension(self.state));
-        let server = axum::Server::bind(&self.socket_addr).serve(
-            self.router
-                .into_make_service_with_connect_info::<SocketAddr>(),
-        );
-        let socket_addr = server.local_addr();
-        SignalingServer {
-            server,
-            socket_addr,
-        }
+
+        let info = self
+            .router
+            .into_make_service_with_connect_info::<SocketAddr>();
+
+        let socket_addr = self.socket_addr;
+        SignalingServer { info, socket_addr }
     }
 }

--- a/matchbox_signaling/src/signaling_server/server.rs
+++ b/matchbox_signaling/src/signaling_server/server.rs
@@ -6,16 +6,21 @@ use crate::{
     },
 };
 use axum::{extract::connect_info::IntoMakeServiceWithConnectInfo, Router};
+use hyper::{server::conn::AddrIncoming, Server};
 use std::net::SocketAddr;
 
 /// Contains the interface end of a signaling server
 #[derive(Debug)]
 pub struct SignalingServer {
-    /// The socket address bound for this server
-    pub(crate) socket_addr: SocketAddr,
+    /// The socket configured for this server
+    pub(crate) requested_addr: SocketAddr,
 
     /// Low-level info for how to build an axum server
     pub(crate) info: IntoMakeServiceWithConnectInfo<Router, SocketAddr>,
+
+    /// Low-level info for how to build an axum server
+    pub(crate) server:
+        Option<Server<AddrIncoming, IntoMakeServiceWithConnectInfo<Router, SocketAddr>>>,
 }
 
 /// Common methods
@@ -35,17 +40,35 @@ impl SignalingServer {
     }
 
     /// Returns the local address this server is bound to
-    pub fn local_addr(&self) -> SocketAddr {
-        self.socket_addr
+    ///
+    /// The server needs to [`bind`] first
+    pub fn local_addr(&self) -> Option<SocketAddr> {
+        self.server.as_ref().map(|s| s.local_addr())
+    }
+
+    /// Binds the server to a socket
+    ///
+    /// Optional: Will happen automatically on [`serve`]
+    pub fn bind(&mut self) -> Result<SocketAddr, crate::Error> {
+        let server = axum::Server::try_bind(&self.requested_addr)
+            .map_err(crate::Error::Bind)?
+            .serve(self.info.clone());
+
+        let addr = server.local_addr();
+        self.server = Some(server);
+        Ok(addr)
     }
 
     /// Serve the signaling server
-    pub async fn serve(self) -> Result<(), crate::Error> {
-        // TODO: Shouldn't this return Result<!, crate::Error>?
-        // todo: use try_serve?
-        let server = axum::Server::bind(&self.socket_addr).serve(self.info);
+    ///
+    /// Will bind if not already bound
+    pub async fn serve(mut self) -> Result<(), crate::Error> {
+        if self.server.is_none() {
+            self.bind()?;
+            assert!(self.server.is_some());
+        }
 
-        match server.await {
+        match self.server.expect("no server, this is a bug").await {
             Ok(()) => Ok(()),
             Err(e) => Err(crate::Error::from(e)),
         }

--- a/matchbox_signaling/tests/client_server.rs
+++ b/matchbox_signaling/tests/client_server.rs
@@ -29,8 +29,8 @@ mod tests {
 
     #[tokio::test]
     async fn ws_connect() {
-        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0)).build();
-        let addr = server.local_addr();
+        let mut server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0)).build();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
@@ -40,8 +40,8 @@ mod tests {
 
     #[tokio::test]
     async fn uuid_assigned() {
-        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0)).build();
-        let addr = server.local_addr();
+        let mut server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0)).build();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         let (mut host, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
@@ -55,8 +55,8 @@ mod tests {
 
     #[tokio::test]
     async fn new_client() {
-        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0)).build();
-        let addr = server.local_addr();
+        let mut server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0)).build();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         let (mut host, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
@@ -77,8 +77,8 @@ mod tests {
 
     #[tokio::test]
     async fn disconnect_client() {
-        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0)).build();
-        let addr = server.local_addr();
+        let mut server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0)).build();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         let (mut host, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
@@ -105,8 +105,8 @@ mod tests {
 
     #[tokio::test]
     async fn signal() {
-        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0)).build();
-        let addr = server.local_addr();
+        let mut server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0)).build();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         let (mut host, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
@@ -146,7 +146,7 @@ mod tests {
     async fn on_connection_req_callback() {
         let (connection_requested_tx, mut connection_requested_rx) = unbounded_channel();
 
-        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
+        let mut server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
             .on_connection_request({
                 let connection_requested_tx = connection_requested_tx.clone();
                 move |_| {
@@ -157,7 +157,7 @@ mod tests {
                 }
             })
             .build();
-        let addr = server.local_addr();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         // Connect
@@ -174,7 +174,7 @@ mod tests {
         let (upgrade_called_tx, mut upgrade_called_rx) = unbounded_channel();
         let (peer_connected_tx, mut peer_connected_rx) = unbounded_channel();
 
-        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
+        let mut server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
             .on_connection_request({
                 let upgrade_called_tx = upgrade_called_tx.clone();
                 move |_| {
@@ -188,7 +188,7 @@ mod tests {
                 move |_| peer_connected_tx.send(()).expect("send peer connected")
             })
             .build();
-        let addr = server.local_addr();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         // Connect
@@ -202,13 +202,13 @@ mod tests {
     async fn on_id_assignment_callback() {
         let (id_assigned_tx, mut id_assigned_rx) = unbounded_channel();
 
-        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
+        let mut server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
             .on_id_assignment({
                 let id_assigned_tx = id_assigned_tx.clone();
                 move |_| id_assigned_tx.send(()).expect("send id assigned")
             })
             .build();
-        let addr = server.local_addr();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         // Connect
@@ -223,13 +223,13 @@ mod tests {
     async fn on_host_connect_callback() {
         let (host_connected_tx, mut host_connected_rx) = unbounded_channel();
 
-        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
+        let mut server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
             .on_host_connected({
                 let host_connected_tx = host_connected_tx.clone();
                 move |_| host_connected_tx.send(()).unwrap()
             })
             .build();
-        let addr = server.local_addr();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         // Connect
@@ -244,7 +244,7 @@ mod tests {
     async fn on_host_disconnect_callback() {
         let (disconnected_tx, mut disconnected_rx) = unbounded_channel::<()>();
 
-        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
+        let mut server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
             .on_host_disconnected({
                 let disconnected_tx = disconnected_tx.clone();
                 move |_| {
@@ -252,7 +252,7 @@ mod tests {
                 }
             })
             .build();
-        let addr = server.local_addr();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         // Connect
@@ -270,13 +270,13 @@ mod tests {
     async fn on_client_connect_callback() {
         let (client_connected_tx, mut client_connected_rx) = unbounded_channel();
 
-        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
+        let mut server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
             .on_client_connected({
                 let client_connected_tx = client_connected_tx.clone();
                 move |_| client_connected_tx.send(()).expect("send client connected")
             })
             .build();
-        let addr = server.local_addr();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         // First Connect = Host
@@ -298,7 +298,7 @@ mod tests {
     async fn on_client_disconnect_callback() {
         let (client_disconnected_tx, mut client_disconnected_rx) = unbounded_channel();
 
-        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
+        let mut server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
             .on_client_disconnected({
                 let client_disconnected_tx = client_disconnected_tx.clone();
                 move |_| {
@@ -308,7 +308,7 @@ mod tests {
                 }
             })
             .build();
-        let addr = server.local_addr();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         // Connect Host

--- a/matchbox_signaling/tests/full_mesh.rs
+++ b/matchbox_signaling/tests/full_mesh.rs
@@ -29,8 +29,8 @@ mod tests {
 
     #[tokio::test]
     async fn ws_connect() {
-        let server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0)).build();
-        let addr = server.local_addr();
+        let mut server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0)).build();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         tokio_tungstenite::connect_async(format!("ws://{addr}/room_a"))
@@ -40,8 +40,8 @@ mod tests {
 
     #[tokio::test]
     async fn uuid_assigned() {
-        let server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0)).build();
-        let addr = server.local_addr();
+        let mut server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0)).build();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         let (mut client, _response) =
@@ -56,8 +56,8 @@ mod tests {
 
     #[tokio::test]
     async fn new_peer() {
-        let server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0)).build();
-        let addr = server.local_addr();
+        let mut server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0)).build();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         let (mut client_a, _response) =
@@ -81,8 +81,8 @@ mod tests {
 
     #[tokio::test]
     async fn disconnect_peer() {
-        let server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0)).build();
-        let addr = server.local_addr();
+        let mut server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0)).build();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         let (mut client_a, _response) =
@@ -112,8 +112,8 @@ mod tests {
 
     #[tokio::test]
     async fn signal() {
-        let server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0)).build();
-        let addr = server.local_addr();
+        let mut server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0)).build();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         let (mut client_a, _response) =
@@ -156,7 +156,7 @@ mod tests {
     async fn on_connection_req_callback() {
         let (connection_requested_tx, mut connection_requested_rx) = unbounded_channel();
 
-        let server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
+        let mut server = SignalingServer::client_server_builder((Ipv4Addr::LOCALHOST, 0))
             .on_connection_request({
                 let connection_requested_tx = connection_requested_tx.clone();
                 move |_| {
@@ -167,7 +167,7 @@ mod tests {
                 }
             })
             .build();
-        let addr = server.local_addr();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         // Connect
@@ -184,7 +184,7 @@ mod tests {
         let (upgrade_called_tx, mut upgrade_called_rx) = unbounded_channel();
         let (peer_connected_tx, mut peer_connected_rx) = unbounded_channel();
 
-        let server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0))
+        let mut server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0))
             .on_connection_request({
                 let upgrade_called_tx = upgrade_called_tx.clone();
                 move |_| {
@@ -198,7 +198,7 @@ mod tests {
                 move |_| peer_connected_tx.send(()).expect("send peer connected")
             })
             .build();
-        let addr = server.local_addr();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         // Connect
@@ -212,13 +212,13 @@ mod tests {
     async fn on_id_assignment_callback() {
         let (id_assigned_tx, mut id_assigned_rx) = unbounded_channel();
 
-        let server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0))
+        let mut server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0))
             .on_id_assignment({
                 let id_assigned_tx = id_assigned_tx.clone();
                 move |_| id_assigned_tx.send(()).expect("send id assigned")
             })
             .build();
-        let addr = server.local_addr();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         // Connect
@@ -233,13 +233,13 @@ mod tests {
     async fn on_connect_callback() {
         let (peer_connected_tx, mut peer_connected_rx) = unbounded_channel();
 
-        let server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0))
+        let mut server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0))
             .on_peer_connected({
                 let peer_connected_tx = peer_connected_tx.clone();
                 move |_| peer_connected_tx.send(()).expect("send peer connected")
             })
             .build();
-        let addr = server.local_addr();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         // Connect
@@ -254,7 +254,7 @@ mod tests {
     async fn on_disconnect_callback() {
         let (disconnected_tx, mut disconnected_rx) = unbounded_channel::<()>();
 
-        let server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0))
+        let mut server = SignalingServer::full_mesh_builder((Ipv4Addr::LOCALHOST, 0))
             .on_peer_disconnected({
                 let disconnected_tx = disconnected_tx.clone();
                 move |_| {
@@ -262,7 +262,7 @@ mod tests {
                 }
             })
             .build();
-        let addr = server.local_addr();
+        let addr = server.bind().unwrap();
         tokio::spawn(server.serve());
 
         // Connect


### PR DESCRIPTION
Alternative to #352 

Axum expects being run in a tokio context, but Bevy isn't that. Use the same approach as we do for `matchbox_socket`, and wrap the async call using `async-compat`

Moves binding to an explicit optional step, and makes `Server::local_addr` return an `Option<SocketAddr>`

Fixes #350 