### PR TITLE
Fix unnecessary caching of `/var/lib/apt/lists/*` in `Dockerfile`

### DIFF
--- a/matchbox_server/Dockerfile
+++ b/matchbox_server/Dockerfile
@@ -18,7 +18,6 @@ COPY matchbox_signaling /usr/src/matchbox_signaling
 RUN cargo build --release
 
 FROM debian:bullseye-slim
-RUN apt-get update && apt-get install -y libssl1.1
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libssl1.1 && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/src/matchbox_server/target/release/matchbox_server /usr/local/bin/matchbox_server
 CMD ["matchbox_server"]

--- a/matchbox_server/Dockerfile
+++ b/matchbox_server/Dockerfile
@@ -7,8 +7,6 @@ FROM rust:1.73-slim-bullseye as builder
 
 WORKDIR /usr/src/matchbox_server/
 
-# cache dependency compilation in a low layer to speed up subsequent builds and
-# save disk space on builders
 COPY README.md /usr/src/README.md
 COPY matchbox_server/Cargo.toml /usr/src/matchbox_server/Cargo.toml
 COPY matchbox_protocol /usr/src/matchbox_protocol


### PR DESCRIPTION
Will make our docker images smaller