### PR TITLE
Add missing `env-filter` feature for signaling examples

### DIFF
--- a/matchbox_signaling/Cargo.toml
+++ b/matchbox_signaling/Cargo.toml
@@ -36,4 +36,4 @@ async-trait = { version = "0.1" }
 
 [dev-dependencies]
 tokio-tungstenite = "0.20.0"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }


### PR DESCRIPTION
Previously, running `cargo run --example client_server` from within `matchbox_signaling` would result in 

```
   Compiling matchbox_signaling v0.7.0 (C:\Users\Johan\dev\matchbox\matchbox_signaling)
error[E0433]: failed to resolve: could not find `EnvFilter` in `tracing_subscriber`
  --> matchbox_signaling\examples\client_server.rs:29:33
   |
29 |             tracing_subscriber::EnvFilter::try_from_default_env()
   |                                 ^^^^^^^^^ could not find `EnvFilter` in `tracing_subscriber`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `matchbox_signaling` (example "client_server") due to previous error
```