### PR TITLE
ci: Explain why toml linting fails

### DIFF
--- a/.github/workflows/lint-toml.yml
+++ b/.github/workflows/lint-toml.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Lint
         run: |
           taplo check --default-schema-catalogs
-          taplo fmt --check
+          taplo fmt --check --diff


### PR DESCRIPTION
Previously it would just error, but not tell you why.