### PR TITLE
ci: Don't run twice on pushes to PR branches

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 name: Code

--- a/.github/workflows/lint-toml.yml
+++ b/.github/workflows/lint-toml.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 name: Lint TOML

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 name: Markdown Lint


### PR DESCRIPTION
There was a minimal difference between a push and a pull_request PR runs on stale branches, but branches based off of main, it would test exactly the same code twice.

As far as I understand, testing the pull request event is best, since it does a merge first, before testing.