### PR TITLE
fix: issue 391

### DIFF
--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -777,7 +777,7 @@ async fn run_socket(
         select! {
             msgloop = message_loop_done => {
                 match msgloop {
-                    Ok(()) => {
+                    Ok(()) | Err(SignalingError::StreamExhausted) => {
                         debug!("Message loop completed");
                         break Ok(())
                     },
@@ -792,6 +792,10 @@ async fn run_socket(
             sigloop = signaling_loop_done => {
                 match sigloop {
                     Ok(()) => debug!("Signaling loop completed"),
+                    Err(SignalingError::StreamExhausted) => {
+                        debug!("Signaling loop completed");
+                        break Ok(());
+                    },
                     Err(e) => {
                         // TODO: Reconnect X attempts if configured to reconnect.
                         error!("The signaling loop finished with an error: {e:?}");


### PR DESCRIPTION
Fixes a regression on WASM where if the peer hung-up in the middle of a connection, it would leave the wasm peer in a reproducible panic condition.

Fixes #391