### PR TITLE
fix: [bevy_ggrs example] add tonemapping_luts bevy feature

### DIFF
--- a/examples/bevy_ggrs/Cargo.toml
+++ b/examples/bevy_ggrs/Cargo.toml
@@ -30,6 +30,7 @@ bevy = { version = "0.12", default-features = false, features = [
   "bevy_sprite",
   "png",
   "webgl2",
+  "tonemapping_luts",
   # gh actions runners don't like wayland
   "x11",
 ] }


### PR DESCRIPTION
fixes https://github.com/johanhelsing/matchbox/issues/398

# With the fix
![image](https://github.com/johanhelsing/matchbox/assets/49416765/57bcb165-0229-44db-b9b3-ca1d5d069df3)

# Without the fix
![image](https://github.com/johanhelsing/matchbox/assets/49416765/03fc15b9-7544-4899-a774-a700f29e7b6e)


# Important caveat
This fix is only for WASM. The native compilation is still broken as per https://github.com/johanhelsing/matchbox/issues/417

# Extra context
Seems that this was forgotten, because the dependency was added for bevy_matchbox
https://github.com/AgustinRamiroDiaz/matchbox/blob/a70b27a5291cf0427e4312c75d6529625fe3e970/bevy_matchbox/Cargo.toml#L50 