### PR TITLE
Feature: matchbox_server docker image GitHub action

### DIFF
--- a/.github/workflows/push-matchbox_server-dockerhub.yml
+++ b/.github/workflows/push-matchbox_server-dockerhub.yml
@@ -19,4 +19,5 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
+          file: matchbox_server/Dockerfile
           tags: ${{ vars.DOCKERHUB_USERNAME }}/matchbox_server:${{github.ref_name}}

--- a/.github/workflows/push-matchbox_server-dockerhub.yml
+++ b/.github/workflows/push-matchbox_server-dockerhub.yml
@@ -1,0 +1,22 @@
+on:
+  push:
+    tags:
+      - "v*"
+
+name: Push `matchbox_server` to Docker Hub
+
+jobs:
+  build:
+    name: Login, Build and Push to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/matchbox_server:${{github.ref_name}}

--- a/.github/workflows/push-matchbox_server-dockerhub.yml
+++ b/.github/workflows/push-matchbox_server-dockerhub.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build and push
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/push-matchbox_server-dockerhub.yml
+++ b/.github/workflows/push-matchbox_server-dockerhub.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/matchbox_server:${{github.ref_name}}
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/matchbox_server:${{github.ref_name}}


### PR DESCRIPTION
Part of https://github.com/johanhelsing/matchbox/issues/372

# What

Adds [this github action](https://github.com/docker/build-push-action) configured for this repo

# Testing done

You can see the triggers of my tests at https://github.com/AgustinRamiroDiaz/matchbox/actions

# Configuration from your side

Requires creating an access token in Docker Hub, and configuring the secret `DOCKERHUB_TOKEN` and the variable `DOCKERHUB_USER` in this repo

![image](https://github.com/johanhelsing/matchbox/assets/49416765/ddcd7d3b-fc33-44fe-9776-a9b310b16559)

![image](https://github.com/johanhelsing/matchbox/assets/49416765/8a6a1f1c-ea95-4cb6-b747-21aa4332d20b)
