### PR TITLE
Remove serde-serialize feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5211,8 +5211,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/matchbox_socket/Cargo.toml
+++ b/matchbox_socket/Cargo.toml
@@ -50,9 +50,7 @@ ggrs = { version = "0.10", default-features = false, optional = true, features =
 ] }
 ws_stream_wasm = { version = "0.7", default-features = false }
 wasm-bindgen-futures = { version = "0.4", default-features = false }
-wasm-bindgen = { version = "0.2", default-features = false, features = [
-  "serde-serialize",
-] }
+wasm-bindgen = { version = "0.2", default-features = false }
 futures-timer = { version = "3.0", default-features = false, features = [
   "wasm-bindgen",
 ] }


### PR DESCRIPTION
This wasn't used and is deprecated due to causing cyclic dependency issues.

Ran into this and it took a while to realise this was the source of the issue, see this thread for more discussion on it: https://github.com/tkaitchuck/aHash/issues/95