### PR TITLE
Fix new warnings in rust 1.77

### DIFF
--- a/bevy_matchbox/src/socket.rs
+++ b/bevy_matchbox/src/socket.rs
@@ -70,6 +70,7 @@ use std::{
 /// }
 /// ```
 #[derive(Resource, Component, Debug)]
+#[allow(dead_code)] // keep the task alive so it doesn't drop before the socket
 pub struct MatchboxSocket<C: BuildablePlurality>(WebRtcSocket<C>, Box<dyn Debug + Send + Sync>);
 
 impl<C: BuildablePlurality> Deref for MatchboxSocket<C> {


### PR DESCRIPTION
After rust 1.77 we started getting warnings about an unused task handle. Looking at previous code, I'm pretty sure we take ownership because we don't want to drop the task before the socket, and we also want to be able to drop the task *when* we want to.

Fixes: #437