### PR TITLE
bevy_matchbox example header comments to include reference to cargo dependency changes when needed for integration.

### DIFF
--- a/bevy_matchbox/examples/hello_host.rs
+++ b/bevy_matchbox/examples/hello_host.rs
@@ -1,4 +1,7 @@
 //! Runs both signaling with server/client topology and runs the host in the same process
+//!    Note: When building a signaling server ensure your cargo has been updated,
+//!    Enable the `signaling` feature in the `bevy_matchbox` dependency:
+//!    bevy_matchbox = { version = "0.n", features = ["signaling"] }
 //!
 //! Sends messages periodically to all connected clients.
 

--- a/bevy_matchbox/examples/hello_host.rs
+++ b/bevy_matchbox/examples/hello_host.rs
@@ -1,9 +1,10 @@
 //! Runs both signaling with server/client topology and runs the host in the same process
-//!    Note: When building a signaling server ensure your cargo has been updated,
-//!    Enable the `signaling` feature in the `bevy_matchbox` dependency:
-//!    bevy_matchbox = { version = "0.n", features = ["signaling"] }
 //!
 //! Sends messages periodically to all connected clients.
+//! 
+//! Note: When building a signaling server ensure your project cargo.toml file has been updated with 
+//! the appropriate dependencies. When building a signaling server, enable the `signaling` feature:
+//! ```toml bevy_matchbox = { version = "0.n", features = ["signaling"] }```
 
 use bevy::{
     app::ScheduleRunnerPlugin, log::LogPlugin, prelude::*, time::common_conditions::on_timer,

--- a/bevy_matchbox/examples/hello_signaling.rs
+++ b/bevy_matchbox/examples/hello_signaling.rs
@@ -1,8 +1,9 @@
 //! Runs a signaling server with server/client topology as a headless bevy
 //! application.
-//!    Note: When building a signaling server ensure your cargo has been updated,
-//!    Enable the `signaling` feature in the `bevy_matchbox` dependency:
-//!    bevy_matchbox = { version = "0.n", features = ["signaling"] }
+//! 
+//! Note: When building a signaling server ensure your project cargo.toml file has been updated with 
+//! the appropriate dependencies. When building a signaling server, enable the `signaling` feature:
+//! ```toml bevy_matchbox = { version = "0.n", features = ["signaling"] }```
 
 use bevy::{app::ScheduleRunnerPlugin, log::LogPlugin, prelude::*, utils::Duration};
 use bevy_matchbox::{matchbox_signaling::SignalingServer, prelude::*};

--- a/bevy_matchbox/examples/hello_signaling.rs
+++ b/bevy_matchbox/examples/hello_signaling.rs
@@ -1,5 +1,8 @@
 //! Runs a signaling server with server/client topology as a headless bevy
 //! application.
+//!    Note: When building a signaling server ensure your cargo has been updated,
+//!    Enable the `signaling` feature in the `bevy_matchbox` dependency:
+//!    bevy_matchbox = { version = "0.n", features = ["signaling"] }
 
 use bevy::{app::ScheduleRunnerPlugin, log::LogPlugin, prelude::*, utils::Duration};
 use bevy_matchbox::{matchbox_signaling::SignalingServer, prelude::*};


### PR DESCRIPTION
Added a reference in the bevy_matchbox example's {hello_host, hello_signaling} comment header to advise updating the local Cargo.toml to enable the necessary features for seamless integration with the example logic.