### PR TITLE
Refactor: Drop typestate pattern for building sockets

### DIFF
--- a/bevy_matchbox/examples/hello.rs
+++ b/bevy_matchbox/examples/hello.rs
@@ -4,6 +4,8 @@
 use bevy::{prelude::*, time::common_conditions::on_timer, utils::Duration};
 use bevy_matchbox::prelude::*;
 
+const CHANNEL_ID: usize = 0;
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -21,22 +23,24 @@ fn start_socket(mut commands: Commands) {
     commands.insert_resource(socket);
 }
 
-fn send_message(mut socket: ResMut<MatchboxSocket<SingleChannel>>) {
+fn send_message(mut socket: ResMut<MatchboxSocket>) {
     let peers: Vec<_> = socket.connected_peers().collect();
 
     for peer in peers {
         let message = "Hello";
         info!("Sending message: {message:?} to {peer}");
-        socket.send(message.as_bytes().into(), peer);
+        socket
+            .channel_mut(CHANNEL_ID)
+            .send(message.as_bytes().into(), peer);
     }
 }
 
-fn receive_messages(mut socket: ResMut<MatchboxSocket<SingleChannel>>) {
+fn receive_messages(mut socket: ResMut<MatchboxSocket>) {
     for (peer, state) in socket.update_peers() {
         info!("{peer}: {state:?}");
     }
 
-    for (_id, message) in socket.receive() {
+    for (_id, message) in socket.channel_mut(CHANNEL_ID).receive() {
         match std::str::from_utf8(&message) {
             Ok(message) => info!("Received message: {message:?}"),
             Err(e) => error!("Failed to convert message to string: {e}"),

--- a/bevy_matchbox/examples/hello_host.rs
+++ b/bevy_matchbox/examples/hello_host.rs
@@ -60,22 +60,22 @@ fn start_host_socket(mut commands: Commands) {
     commands.insert_resource(socket);
 }
 
-fn send_message(mut socket: ResMut<MatchboxSocket<SingleChannel>>) {
+fn send_message(mut socket: ResMut<MatchboxSocket>) {
     let peers: Vec<_> = socket.connected_peers().collect();
 
     for peer in peers {
         let message = "Hello, I'm the host";
         info!("Sending message: {message:?} to {peer}");
-        socket.send(message.as_bytes().into(), peer);
+        socket.channel_mut(0).send(message.as_bytes().into(), peer);
     }
 }
 
-fn receive_messages(mut socket: ResMut<MatchboxSocket<SingleChannel>>) {
+fn receive_messages(mut socket: ResMut<MatchboxSocket>) {
     for (peer, state) in socket.update_peers() {
         info!("{peer}: {state:?}");
     }
 
-    for (_id, message) in socket.receive() {
+    for (_id, message) in socket.channel_mut(0).receive() {
         match std::str::from_utf8(&message) {
             Ok(message) => info!("Received message: {message:?}"),
             Err(e) => error!("Failed to convert message to string: {e}"),

--- a/bevy_matchbox/src/lib.rs
+++ b/bevy_matchbox/src/lib.rs
@@ -18,10 +18,7 @@ cfg_if! {
 pub mod prelude {
     pub use crate::{CloseSocketExt, MatchboxSocket, OpenSocketExt};
     use cfg_if::cfg_if;
-    pub use matchbox_socket::{
-        BuildablePlurality, ChannelConfig, MultipleChannels, PeerId, PeerState, SingleChannel,
-        WebRtcSocketBuilder,
-    };
+    pub use matchbox_socket::{ChannelConfig, PeerId, PeerState, WebRtcSocketBuilder};
 
     cfg_if! {
         if #[cfg(all(not(target_arch = "wasm32"), feature = "signaling"))] {

--- a/bevy_matchbox/src/signaling.rs
+++ b/bevy_matchbox/src/signaling.rs
@@ -163,8 +163,10 @@ impl MatchboxServer {
 
 #[cfg(test)]
 mod tests {
-    use crate::matchbox_signaling::topologies::client_server::{ClientServer, ClientServerState};
-    use crate::prelude::*;
+    use crate::{
+        matchbox_signaling::topologies::client_server::{ClientServer, ClientServerState},
+        prelude::*,
+    };
     use bevy::prelude::*;
     use std::net::Ipv4Addr;
 

--- a/bevy_matchbox/src/socket.rs
+++ b/bevy_matchbox/src/socket.rs
@@ -4,12 +4,9 @@ use bevy::{
     tasks::IoTaskPool,
 };
 pub use matchbox_socket;
-use matchbox_socket::{
-    BuildablePlurality, MessageLoopFuture, SingleChannel, WebRtcSocket, WebRtcSocketBuilder,
-};
+use matchbox_socket::{MessageLoopFuture, WebRtcSocket, WebRtcSocketBuilder};
 use std::{
     fmt::Debug,
-    marker::PhantomData,
     ops::{Deref, DerefMut},
 };
 
@@ -28,7 +25,7 @@ use std::{
 ///
 /// fn close_socket_system(
 ///     mut commands: Commands,
-///     socket: Query<Entity, With<MatchboxSocket<SingleChannel>>>
+///     socket: Query<Entity, With<MatchboxSocket>>
 /// ) {
 ///     let socket = socket.single();
 ///     commands.entity(socket).despawn();
@@ -46,7 +43,7 @@ use std::{
 /// }
 ///
 /// fn close_socket_system(mut commands: Commands) {
-///     commands.close_socket::<SingleChannel>();
+///     commands.close_socket();
 /// }
 /// ```
 ///
@@ -58,7 +55,7 @@ use std::{
 /// fn open_socket_system(mut commands: Commands) {
 ///     let room_url = "wss://matchbox.example.com";
 ///
-///     let socket: MatchboxSocket<SingleChannel> = WebRtcSocketBuilder::new(room_url)
+///     let socket: MatchboxSocket = WebRtcSocketBuilder::new(room_url)
 ///         .add_channel(ChannelConfig::reliable())
 ///         .into();
 ///
@@ -66,35 +63,35 @@ use std::{
 /// }
 ///
 /// fn close_socket_system(mut commands: Commands) {
-///     commands.remove_resource::<MatchboxSocket<SingleChannel>>();
+///     commands.remove_resource::<MatchboxSocket>();
 /// }
 /// ```
 #[derive(Resource, Component, Debug)]
 #[allow(dead_code)] // keep the task alive so it doesn't drop before the socket
-pub struct MatchboxSocket<C: BuildablePlurality>(WebRtcSocket<C>, Box<dyn Debug + Send + Sync>);
+pub struct MatchboxSocket(WebRtcSocket, Box<dyn Debug + Send + Sync>);
 
-impl<C: BuildablePlurality> Deref for MatchboxSocket<C> {
-    type Target = WebRtcSocket<C>;
+impl Deref for MatchboxSocket {
+    type Target = WebRtcSocket;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<C: BuildablePlurality> DerefMut for MatchboxSocket<C> {
+impl DerefMut for MatchboxSocket {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl<C: BuildablePlurality> From<WebRtcSocketBuilder<C>> for MatchboxSocket<C> {
-    fn from(builder: WebRtcSocketBuilder<C>) -> Self {
+impl From<WebRtcSocketBuilder> for MatchboxSocket {
+    fn from(builder: WebRtcSocketBuilder) -> Self {
         Self::from(builder.build())
     }
 }
 
-impl<C: BuildablePlurality> From<(WebRtcSocket<C>, MessageLoopFuture)> for MatchboxSocket<C> {
-    fn from((socket, message_loop_fut): (WebRtcSocket<C>, MessageLoopFuture)) -> Self {
+impl From<(WebRtcSocket, MessageLoopFuture)> for MatchboxSocket {
+    fn from((socket, message_loop_fut): (WebRtcSocket, MessageLoopFuture)) -> Self {
         let task_pool = IoTaskPool::get();
         let task = task_pool.spawn(message_loop_fut);
         MatchboxSocket(socket, Box::new(task))
@@ -102,32 +99,32 @@ impl<C: BuildablePlurality> From<(WebRtcSocket<C>, MessageLoopFuture)> for Match
 }
 
 /// A [`Command`] used to open a [`MatchboxSocket`] and allocate it as a resource.
-struct OpenSocket<C: BuildablePlurality>(WebRtcSocketBuilder<C>);
+struct OpenSocket(WebRtcSocketBuilder);
 
-impl<C: BuildablePlurality + 'static> Command for OpenSocket<C> {
+impl Command for OpenSocket {
     fn apply(self, world: &mut World) {
         world.insert_resource(MatchboxSocket::from(self.0));
     }
 }
 
 /// A [`Commands`] extension used to open a [`MatchboxSocket`] and allocate it as a resource.
-pub trait OpenSocketExt<C: BuildablePlurality> {
+pub trait OpenSocketExt {
     /// Opens a [`MatchboxSocket`] and allocates it as a resource.
-    fn open_socket(&mut self, socket_builder: WebRtcSocketBuilder<C>);
+    fn open_socket(&mut self, socket_builder: WebRtcSocketBuilder);
 }
 
-impl<C: BuildablePlurality + 'static> OpenSocketExt<C> for Commands<'_, '_> {
-    fn open_socket(&mut self, socket_builder: WebRtcSocketBuilder<C>) {
+impl OpenSocketExt for Commands<'_, '_> {
+    fn open_socket(&mut self, socket_builder: WebRtcSocketBuilder) {
         self.add(OpenSocket(socket_builder))
     }
 }
 
 /// A [`Command`] used to close a [`WebRtcSocket`], deleting the [`MatchboxSocket`] resource.
-struct CloseSocket<C: BuildablePlurality>(PhantomData<C>);
+struct CloseSocket;
 
-impl<C: BuildablePlurality + 'static> Command for CloseSocket<C> {
+impl Command for CloseSocket {
     fn apply(self, world: &mut World) {
-        world.remove_resource::<MatchboxSocket<C>>();
+        world.remove_resource::<MatchboxSocket>();
     }
 }
 
@@ -135,16 +132,16 @@ impl<C: BuildablePlurality + 'static> Command for CloseSocket<C> {
 /// resource.
 pub trait CloseSocketExt {
     /// Delete the [`MatchboxSocket`] resource.
-    fn close_socket<C: BuildablePlurality + 'static>(&mut self);
+    fn close_socket(&mut self);
 }
 
 impl CloseSocketExt for Commands<'_, '_> {
-    fn close_socket<C: BuildablePlurality + 'static>(&mut self) {
-        self.add(CloseSocket::<C>(PhantomData))
+    fn close_socket(&mut self) {
+        self.add(CloseSocket)
     }
 }
 
-impl MatchboxSocket<SingleChannel> {
+impl MatchboxSocket {
     /// Create a new socket with a single unreliable channel
     ///
     /// ```rust
@@ -157,7 +154,7 @@ impl MatchboxSocket<SingleChannel> {
     ///     commands.spawn(socket);
     /// }
     /// ```
-    pub fn new_unreliable(room_url: impl Into<String>) -> MatchboxSocket<SingleChannel> {
+    pub fn new_unreliable(room_url: impl Into<String>) -> MatchboxSocket {
         Self::from(WebRtcSocket::new_unreliable(room_url))
     }
 
@@ -173,7 +170,7 @@ impl MatchboxSocket<SingleChannel> {
     ///     commands.spawn(socket);
     /// }
     /// ```
-    pub fn new_reliable(room_url: impl Into<String>) -> MatchboxSocket<SingleChannel> {
+    pub fn new_reliable(room_url: impl Into<String>) -> MatchboxSocket {
         Self::from(WebRtcSocket::new_reliable(room_url))
     }
 
@@ -190,7 +187,7 @@ impl MatchboxSocket<SingleChannel> {
     /// }
     /// ```
     #[cfg(feature = "ggrs")]
-    pub fn new_ggrs(room_url: impl Into<String>) -> MatchboxSocket<SingleChannel> {
+    pub fn new_ggrs(room_url: impl Into<String>) -> MatchboxSocket {
         Self::from(WebRtcSocket::new_ggrs(room_url))
     }
 }

--- a/bevy_matchbox/src/socket.rs
+++ b/bevy_matchbox/src/socket.rs
@@ -173,21 +173,4 @@ impl MatchboxSocket {
     pub fn new_reliable(room_url: impl Into<String>) -> MatchboxSocket {
         Self::from(WebRtcSocket::new_reliable(room_url))
     }
-
-    /// Create a new socket with a single ggrs-compatible channel
-    ///
-    /// ```rust
-    /// use bevy_matchbox::prelude::*;
-    /// use bevy::prelude::*;
-    ///
-    /// fn open_channel_system(mut commands: Commands) {
-    ///     let room_url = "wss://matchbox.example.com";
-    ///     let socket = MatchboxSocket::new_ggrs(room_url);
-    ///     commands.spawn(socket);
-    /// }
-    /// ```
-    #[cfg(feature = "ggrs")]
-    pub fn new_ggrs(room_url: impl Into<String>) -> MatchboxSocket {
-        Self::from(WebRtcSocket::new_ggrs(room_url))
-    }
 }

--- a/examples/bevy_ggrs/src/box_game.rs
+++ b/examples/bevy_ggrs/src/box_game.rs
@@ -24,8 +24,8 @@ const FRICTION: f32 = 0.0018;
 const PLANE_SIZE: f32 = 5.0;
 const CUBE_SIZE: f32 = 0.2;
 
-// You need to define a config struct to bundle all the generics of GGRS. bevy_ggrs provides a sensible default in `GgrsConfig`.
-// (optional) You can define a type here for brevity.
+// You need to define a config struct to bundle all the generics of GGRS. bevy_ggrs provides a
+// sensible default in `GgrsConfig`. (optional) You can define a type here for brevity.
 pub type BoxConfig = GgrsConfig<BoxInput, PeerId>;
 
 #[repr(C)]
@@ -58,7 +58,8 @@ pub struct FrameCount {
     pub frame: u32,
 }
 
-/// Collects player inputs during [`ReadInputs`](`bevy_ggrs::ReadInputs`) and creates a [`LocalInputs`] resource.
+/// Collects player inputs during [`ReadInputs`](`bevy_ggrs::ReadInputs`) and creates a
+/// [`LocalInputs`] resource.
 pub fn read_local_inputs(
     mut commands: Commands,
     keyboard_input: Res<ButtonInput<KeyCode>>,
@@ -154,8 +155,9 @@ pub fn setup_scene(
 }
 
 // Example system, manipulating a resource, will be added to the rollback schedule.
-// Increases the frame count by 1 every update step. If loading and saving resources works correctly,
-// you should see this resource rolling back, counting back up and finally increasing by 1 every update step
+// Increases the frame count by 1 every update step. If loading and saving resources works
+// correctly, you should see this resource rolling back, counting back up and finally increasing by
+// 1 every update step
 #[allow(dead_code)]
 pub fn increase_frame_system(mut frame_count: ResMut<FrameCount>) {
     frame_count.frame += 1;
@@ -167,7 +169,8 @@ pub fn increase_frame_system(mut frame_count: ResMut<FrameCount>) {
 #[allow(dead_code)]
 pub fn move_cube_system(
     mut query: Query<(&mut Transform, &mut Velocity, &Player), With<Rollback>>,
-    //                                                              ^------^ Added by `add_rollback` earlier
+    //                                                              ^------^ Added by
+    // `add_rollback` earlier
     inputs: Res<PlayerInputs<BoxConfig>>,
     // Thanks to RollbackTimePlugin, this is rollback safe
     time: Res<Time>,

--- a/examples/bevy_ggrs/src/main.rs
+++ b/examples/bevy_ggrs/src/main.rs
@@ -29,9 +29,11 @@ fn main() {
         .set_rollback_schedule_fps(FPS)
         .add_systems(ReadInputs, read_local_inputs)
         // Rollback behavior can be customized using a variety of extension methods and plugins:
-        // The FrameCount resource implements Copy, we can use that to have minimal overhead rollback
+        // The FrameCount resource implements Copy, we can use that to have minimal overhead
+        // rollback
         .rollback_resource_with_copy::<FrameCount>()
-        // Transform and Velocity components only implement Clone, so instead we'll use that to snapshot and rollback with
+        // Transform and Velocity components only implement Clone, so instead we'll use that to
+        // snapshot and rollback with
         .rollback_component_with_clone::<Transform>()
         .rollback_component_with_clone::<Velocity>()
         .insert_resource(ClearColor(SKY_COLOR))
@@ -66,7 +68,7 @@ fn start_matchbox_socket(mut commands: Commands, args: Res<Args>) {
     let room_url = format!("{}/{}", &args.matchbox, room_id);
     info!("connecting to matchbox server: {room_url:?}");
 
-    commands.insert_resource(MatchboxSocket::new_ggrs(room_url));
+    commands.insert_resource(MatchboxSocket::new_unreliable(room_url));
 }
 
 // Marker components for UI

--- a/examples/bevy_ggrs/src/main.rs
+++ b/examples/bevy_ggrs/src/main.rs
@@ -124,7 +124,7 @@ fn lobby_cleanup(query: Query<Entity, With<LobbyUI>>, mut commands: Commands) {
 fn lobby_system(
     mut app_state: ResMut<NextState<AppState>>,
     args: Res<Args>,
-    mut socket: ResMut<MatchboxSocket<SingleChannel>>,
+    mut socket: ResMut<MatchboxSocket>,
     mut commands: Commands,
     mut query: Query<&mut Text, With<LobbyText>>,
 ) {

--- a/examples/error_handling/src/main.rs
+++ b/examples/error_handling/src/main.rs
@@ -4,6 +4,8 @@ use log::{info, warn};
 use matchbox_socket::{Error as SocketError, PeerId, PeerState, WebRtcSocket};
 use std::time::Duration;
 
+const CHANNEL_ID: usize = 0;
+
 #[cfg(target_arch = "wasm32")]
 fn main() {
     // Setup logging
@@ -65,7 +67,7 @@ async fn async_main() {
                 PeerState::Connected => {
                     info!("Peer joined: {peer}");
                     let packet = "hello friend!".as_bytes().to_vec().into_boxed_slice();
-                    socket.send(packet, peer);
+                    socket.channel_mut(CHANNEL_ID).send(packet, peer);
                 }
                 PeerState::Disconnected => {
                     info!("Peer left: {peer}");
@@ -74,7 +76,7 @@ async fn async_main() {
         }
 
         // Accept any messages incoming
-        for (peer, packet) in socket.receive() {
+        for (peer, packet) in socket.channel_mut(CHANNEL_ID).receive() {
             let message = String::from_utf8_lossy(&packet);
             info!("Message from {peer}: {message:?}");
         }
@@ -85,7 +87,7 @@ async fn async_main() {
                 let peers: Vec<PeerId> = socket.connected_peers().collect();
                 for peer in peers {
                     let packet = "ping!".as_bytes().to_vec().into_boxed_slice();
-                    socket.send(packet, peer);
+                    socket.channel_mut(CHANNEL_ID).send(packet, peer);
                 }
                 timeout.reset(Duration::from_millis(10));
             }

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -4,6 +4,8 @@ use log::info;
 use matchbox_socket::{PeerState, WebRtcSocket};
 use std::time::Duration;
 
+const CHANNEL_ID: usize = 0;
+
 #[cfg(target_arch = "wasm32")]
 fn main() {
     // Setup logging
@@ -46,7 +48,7 @@ async fn async_main() {
                 PeerState::Connected => {
                     info!("Peer joined: {peer}");
                     let packet = "hello friend!".as_bytes().to_vec().into_boxed_slice();
-                    socket.send(packet, peer);
+                    socket.channel_mut(CHANNEL_ID).send(packet, peer);
                 }
                 PeerState::Disconnected => {
                     info!("Peer left: {peer}");
@@ -55,7 +57,7 @@ async fn async_main() {
         }
 
         // Accept any messages incoming
-        for (peer, packet) in socket.receive() {
+        for (peer, packet) in socket.channel_mut(CHANNEL_ID).receive() {
             let message = String::from_utf8_lossy(&packet);
             info!("Message from {peer}: {message:?}");
         }

--- a/matchbox_socket/src/ggrs_socket.rs
+++ b/matchbox_socket/src/ggrs_socket.rs
@@ -1,48 +1,7 @@
 use ggrs::{Message, PlayerType};
 use matchbox_protocol::PeerId;
 
-use crate::{
-    ChannelConfig, MessageLoopFuture, Packet, WebRtcChannel, WebRtcSocket, WebRtcSocketBuilder,
-};
-
-pub const GGRS_CHANNEL_ID: usize = 0;
-
-impl ChannelConfig {
-    /// Creates a [`ChannelConfig`] suitable for use with GGRS.
-    pub fn ggrs() -> Self {
-        Self::unreliable()
-    }
-}
-
-impl WebRtcSocketBuilder {
-    /// Adds a new channel suitable for use with GGRS to the [`WebRtcSocket`] configuration.
-    ///
-    /// This must be called as the first channel.
-    pub fn add_ggrs_channel(mut self) -> WebRtcSocketBuilder {
-        assert_eq!(
-            self.config.channels.len(),
-            GGRS_CHANNEL_ID,
-            "ggrs channel is expected to be the first channel added"
-        );
-        self.config.channels.push(ChannelConfig::ggrs());
-        self
-    }
-}
-
-impl WebRtcSocket {
-    /// Creates a [`WebRtcSocket`] and the corresponding [`MessageLoopFuture`] for a
-    /// socket with a single channel configured correctly for usage with GGRS.
-    ///
-    /// The returned [`MessageLoopFuture`] should be awaited in order for messages to
-    /// be sent and received.
-    ///
-    /// Please use the [`WebRtcSocketBuilder`] to create non-trivial sockets.
-    pub fn new_ggrs(room_url: impl Into<String>) -> (WebRtcSocket, MessageLoopFuture) {
-        WebRtcSocketBuilder::new(room_url)
-            .add_channel(ChannelConfig::ggrs())
-            .build()
-    }
-}
+use crate::{Packet, WebRtcChannel, WebRtcSocket};
 
 impl WebRtcSocket {
     /// Returns a Vec of connected peers as [`ggrs::PlayerType`]
@@ -80,22 +39,22 @@ fn deserialize_packet(message: (PeerId, Packet)) -> (PeerId, Message) {
     (message.0, bincode::deserialize(&message.1).unwrap())
 }
 
-impl ggrs::NonBlockingSocket<PeerId> for WebRtcSocket {
-    fn send_to(&mut self, msg: &Message, addr: &PeerId) {
-        self.channel_mut(GGRS_CHANNEL_ID)
-            .send(build_packet(msg), *addr);
-    }
-    fn receive_all_messages(&mut self) -> Vec<(PeerId, Message)> {
-        self.channel_mut(GGRS_CHANNEL_ID)
-            .receive()
-            .into_iter()
-            .map(deserialize_packet)
-            .collect()
-    }
-}
-
 impl ggrs::NonBlockingSocket<PeerId> for WebRtcChannel {
     fn send_to(&mut self, msg: &Message, addr: &PeerId) {
+        if self.config().max_retransmits != Some(0) || self.config().ordered {
+            // Using a reliable or ordered channel with ggrs is wasteful in that ggrs implements its
+            // own reliability layer (including unconfirmed inputs in frames) and can
+            // handle out of order messages just fine on its own.
+            // It's likely that in poor network conditions this will cause GGRS to unnecessarily
+            // delay confirming or rolling back simulation frames, which will impact performance
+            // (or, worst case, cause GGRS to temporarily stop advancing frames).
+            // So we better warn the user about this.
+            log::warn!(
+                "Sending GGRS traffic over reliable or ordered channel ({:?}), which may reduce performance.\
+                You should use an unreliable and unordered channel instead.",
+                self.config()
+            );
+        }
         self.send(build_packet(msg), *addr);
     }
 

--- a/matchbox_socket/src/ggrs_socket.rs
+++ b/matchbox_socket/src/ggrs_socket.rs
@@ -1,12 +1,11 @@
-use std::marker::PhantomData;
-
 use ggrs::{Message, PlayerType};
 use matchbox_protocol::PeerId;
 
 use crate::{
-    ChannelConfig, ChannelPlurality, MessageLoopFuture, MultipleChannels, NoChannels, Packet,
-    SingleChannel, WebRtcChannel, WebRtcSocket, WebRtcSocketBuilder,
+    ChannelConfig, MessageLoopFuture, Packet, WebRtcChannel, WebRtcSocket, WebRtcSocketBuilder,
 };
+
+pub const GGRS_CHANNEL_ID: usize = 0;
 
 impl ChannelConfig {
     /// Creates a [`ChannelConfig`] suitable for use with GGRS.
@@ -15,35 +14,18 @@ impl ChannelConfig {
     }
 }
 
-impl WebRtcSocketBuilder<NoChannels> {
+impl WebRtcSocketBuilder {
     /// Adds a new channel suitable for use with GGRS to the [`WebRtcSocket`] configuration.
-    pub fn add_ggrs_channel(mut self) -> WebRtcSocketBuilder<SingleChannel> {
+    ///
+    /// This must be called as the first channel.
+    pub fn add_ggrs_channel(mut self) -> WebRtcSocketBuilder {
+        assert_eq!(
+            self.config.channels.len(),
+            GGRS_CHANNEL_ID,
+            "ggrs channel is expected to be the first channel added"
+        );
         self.config.channels.push(ChannelConfig::ggrs());
-        WebRtcSocketBuilder {
-            config: self.config,
-            channel_plurality: PhantomData,
-        }
-    }
-}
-
-impl WebRtcSocketBuilder<SingleChannel> {
-    /// Adds a new channel suitable for use with GGRS to the [`WebRtcSocket`] configuration.
-    pub fn add_ggrs_channel(mut self) -> WebRtcSocketBuilder<MultipleChannels> {
-        self.config.channels.push(ChannelConfig::ggrs());
-        WebRtcSocketBuilder {
-            config: self.config,
-            channel_plurality: PhantomData,
-        }
-    }
-}
-impl WebRtcSocketBuilder<MultipleChannels> {
-    /// Adds a new channel suitable for use with GGRS to the [`WebRtcSocket`] configuration.
-    pub fn add_ggrs_channel(mut self) -> WebRtcSocketBuilder<MultipleChannels> {
-        self.config.channels.push(ChannelConfig::ggrs());
-        WebRtcSocketBuilder {
-            config: self.config,
-            channel_plurality: PhantomData,
-        }
+        self
     }
 }
 
@@ -55,16 +37,14 @@ impl WebRtcSocket {
     /// be sent and received.
     ///
     /// Please use the [`WebRtcSocketBuilder`] to create non-trivial sockets.
-    pub fn new_ggrs(
-        room_url: impl Into<String>,
-    ) -> (WebRtcSocket<SingleChannel>, MessageLoopFuture) {
+    pub fn new_ggrs(room_url: impl Into<String>) -> (WebRtcSocket, MessageLoopFuture) {
         WebRtcSocketBuilder::new(room_url)
             .add_channel(ChannelConfig::ggrs())
             .build()
     }
 }
 
-impl<C: ChannelPlurality> WebRtcSocket<C> {
+impl WebRtcSocket {
     /// Returns a Vec of connected peers as [`ggrs::PlayerType`]
     pub fn players(&mut self) -> Vec<PlayerType<PeerId>> {
         let Some(our_id) = self.id() else {
@@ -100,12 +80,17 @@ fn deserialize_packet(message: (PeerId, Packet)) -> (PeerId, Message) {
     (message.0, bincode::deserialize(&message.1).unwrap())
 }
 
-impl ggrs::NonBlockingSocket<PeerId> for WebRtcSocket<SingleChannel> {
+impl ggrs::NonBlockingSocket<PeerId> for WebRtcSocket {
     fn send_to(&mut self, msg: &Message, addr: &PeerId) {
-        self.send(build_packet(msg), *addr);
+        self.channel_mut(GGRS_CHANNEL_ID)
+            .send(build_packet(msg), *addr);
     }
     fn receive_all_messages(&mut self) -> Vec<(PeerId, Message)> {
-        self.receive().into_iter().map(deserialize_packet).collect()
+        self.channel_mut(GGRS_CHANNEL_ID)
+            .receive()
+            .into_iter()
+            .map(deserialize_packet)
+            .collect()
     }
 }
 

--- a/matchbox_socket/src/lib.rs
+++ b/matchbox_socket/src/lib.rs
@@ -10,7 +10,8 @@ mod webrtc_socket;
 pub use error::Error;
 pub use matchbox_protocol::PeerId;
 pub use webrtc_socket::{
-    error::ChannelError, BuildablePlurality, ChannelConfig, ChannelPlurality, MessageLoopFuture,
-    MultipleChannels, NoChannels, Packet, PeerState, RtcIceServerConfig, SingleChannel,
+    error::ChannelError, ChannelConfig, MessageLoopFuture, Packet, PeerState, RtcIceServerConfig,
     WebRtcChannel, WebRtcSocket, WebRtcSocketBuilder,
 };
+#[cfg(feature = "ggrs")]
+pub use ggrs_socket::GGRS_CHANNEL_ID;

--- a/matchbox_socket/src/lib.rs
+++ b/matchbox_socket/src/lib.rs
@@ -13,5 +13,3 @@ pub use webrtc_socket::{
     error::ChannelError, ChannelConfig, MessageLoopFuture, Packet, PeerState, RtcIceServerConfig,
     WebRtcChannel, WebRtcSocket, WebRtcSocketBuilder,
 };
-#[cfg(feature = "ggrs")]
-pub use ggrs_socket::GGRS_CHANNEL_ID;

--- a/matchbox_socket/src/webrtc_socket/mod.rs
+++ b/matchbox_socket/src/webrtc_socket/mod.rs
@@ -16,8 +16,7 @@ use matchbox_protocol::PeerId;
 use messages::*;
 pub(crate) use socket::MessageLoopChannels;
 pub use socket::{
-    BuildablePlurality, ChannelConfig, ChannelPlurality, MultipleChannels, NoChannels, PeerState,
-    RtcIceServerConfig, SingleChannel, WebRtcChannel, WebRtcSocket, WebRtcSocketBuilder,
+    ChannelConfig, PeerState, RtcIceServerConfig, WebRtcChannel, WebRtcSocket, WebRtcSocketBuilder,
 };
 use std::{collections::HashMap, pin::Pin, time::Duration};
 

--- a/matchbox_socket/src/webrtc_socket/native.rs
+++ b/matchbox_socket/src/webrtc_socket/native.rs
@@ -4,7 +4,7 @@ use crate::{
         error::SignalingError,
         messages::PeerSignal,
         signal_peer::SignalPeer,
-        socket::{create_data_channels_ready_fut, new_senders_and_receivers},
+        socket::create_data_channels_ready_fut,
         ChannelConfig, Messenger, Packet, Signaller,
     },
     RtcIceServerConfig,
@@ -312,6 +312,14 @@ impl Messenger for NativeMessenger {
         .compat() // Required to run tokio futures with other async executors
         .await
     }
+}
+
+fn new_senders_and_receivers<T>(
+    channel_configs: &[ChannelConfig],
+) -> (Vec<UnboundedSender<T>>, Vec<UnboundedReceiver<T>>) {
+    (0..channel_configs.len())
+        .map(|_| futures_channel::mpsc::unbounded())
+        .unzip()
 }
 
 async fn complete_handshake(

--- a/matchbox_socket/src/webrtc_socket/native.rs
+++ b/matchbox_socket/src/webrtc_socket/native.rs
@@ -1,11 +1,8 @@
 use super::{HandshakeResult, PacketSendError, PeerDataSender};
 use crate::{
     webrtc_socket::{
-        error::SignalingError,
-        messages::PeerSignal,
-        signal_peer::SignalPeer,
-        socket::create_data_channels_ready_fut,
-        ChannelConfig, Messenger, Packet, Signaller,
+        error::SignalingError, messages::PeerSignal, signal_peer::SignalPeer,
+        socket::create_data_channels_ready_fut, ChannelConfig, Messenger, Packet, Signaller,
     },
     RtcIceServerConfig,
 };

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -10,7 +10,7 @@ use futures::{future::Fuse, select, Future, FutureExt, StreamExt};
 use futures_channel::mpsc::{SendError, TrySendError, UnboundedReceiver, UnboundedSender};
 use log::{debug, error};
 use matchbox_protocol::PeerId;
-use std::{collections::HashMap, marker::PhantomData, pin::Pin, time::Duration};
+use std::{collections::HashMap, pin::Pin, time::Duration};
 
 /// Configuration options for an ICE server connection.
 /// See also: <https://developer.mozilla.org/en-US/docs/Web/API/RTCIceServer#example>
@@ -73,31 +73,6 @@ impl Default for RtcIceServerConfig {
     }
 }
 
-/// Tags types which are used to indicate the number of [`WebRtcChannel`]s or
-/// [`ChannelConfig`]s in a [`WebRtcSocket`] or [`WebRtcSocketBuilder`] respectively.
-pub trait ChannelPlurality: Send + Sync {}
-
-/// Tags types which are used to indicate a quantity of [`ChannelConfig`]s which can be
-/// used to build a [`WebRtcSocket`].
-pub trait BuildablePlurality: ChannelPlurality {}
-
-/// Indicates that the type has no [`WebRtcChannel`]s or [`ChannelConfig`]s.
-#[derive(Debug)]
-pub struct NoChannels;
-impl ChannelPlurality for NoChannels {}
-
-/// Indicates that the type has exactly one [`WebRtcChannel`] or [`ChannelConfig`].
-#[derive(Debug)]
-pub struct SingleChannel;
-impl ChannelPlurality for SingleChannel {}
-impl BuildablePlurality for SingleChannel {}
-
-/// Indicates that the type has more than one [`WebRtcChannel`]s or [`ChannelConfig`]s.
-#[derive(Debug)]
-pub struct MultipleChannels;
-impl ChannelPlurality for MultipleChannels {}
-impl BuildablePlurality for MultipleChannels {}
-
 #[derive(Debug, Clone)]
 pub(crate) struct SocketConfig {
     /// The url for the room to connect to
@@ -128,9 +103,8 @@ pub(crate) struct SocketConfig {
 /// [`WebRtcSocketBuilder::add_channel`] before calling
 /// [`WebRtcSocketBuilder::build`] to produce the desired [`WebRtcSocket`].
 #[derive(Debug, Clone)]
-pub struct WebRtcSocketBuilder<C: ChannelPlurality = NoChannels> {
+pub struct WebRtcSocketBuilder {
     pub(crate) config: SocketConfig,
-    pub(crate) channel_plurality: PhantomData<C>,
 }
 
 impl WebRtcSocketBuilder {
@@ -148,7 +122,6 @@ impl WebRtcSocketBuilder {
                 attempts: Some(3),
                 keep_alive_interval: Some(Duration::from_secs(10)),
             },
-            channel_plurality: PhantomData,
         }
     }
 
@@ -179,101 +152,35 @@ impl WebRtcSocketBuilder {
         self.config.keep_alive_interval = interval;
         self
     }
-}
 
-impl WebRtcSocketBuilder<NoChannels> {
     /// Adds a new channel to the [`WebRtcSocket`] configuration according to a [`ChannelConfig`].
-    pub fn add_channel(mut self, config: ChannelConfig) -> WebRtcSocketBuilder<SingleChannel> {
-        self.config.channels.push(config);
-        WebRtcSocketBuilder {
-            config: self.config,
-            channel_plurality: PhantomData,
-        }
-    }
-
-    /// Adds a new unreliable channel to the [`WebRtcSocket`] configuration.
-    pub fn add_unreliable_channel(mut self) -> WebRtcSocketBuilder<SingleChannel> {
-        self.config.channels.push(ChannelConfig::unreliable());
-        WebRtcSocketBuilder {
-            config: self.config,
-            channel_plurality: PhantomData,
-        }
-    }
-
-    /// Adds a new reliable channel to the [`WebRtcSocket`] configuration.
-    pub fn add_reliable_channel(mut self) -> WebRtcSocketBuilder<SingleChannel> {
-        self.config.channels.push(ChannelConfig::reliable());
-        WebRtcSocketBuilder {
-            config: self.config,
-            channel_plurality: PhantomData,
-        }
-    }
-}
-
-impl WebRtcSocketBuilder<SingleChannel> {
-    /// Adds a new channel to the [`WebRtcSocket`] configuration according to a [`ChannelConfig`].
-    pub fn add_channel(mut self, config: ChannelConfig) -> WebRtcSocketBuilder<MultipleChannels> {
-        self.config.channels.push(config);
-        WebRtcSocketBuilder {
-            config: self.config,
-            channel_plurality: PhantomData,
-        }
-    }
-
-    /// Adds a new unreliable channel to the [`WebRtcSocket`] configuration.
-    pub fn add_unreliable_channel(mut self) -> WebRtcSocketBuilder<MultipleChannels> {
-        self.config.channels.push(ChannelConfig::unreliable());
-        WebRtcSocketBuilder {
-            config: self.config,
-            channel_plurality: PhantomData,
-        }
-    }
-
-    /// Adds a new reliable channel to the [`WebRtcSocket`] configuration.
-    pub fn add_reliable_channel(mut self) -> WebRtcSocketBuilder<MultipleChannels> {
-        self.config.channels.push(ChannelConfig::reliable());
-        WebRtcSocketBuilder {
-            config: self.config,
-            channel_plurality: PhantomData,
-        }
-    }
-}
-impl WebRtcSocketBuilder<MultipleChannels> {
-    /// Adds a new channel to the [`WebRtcSocket`] configuration according to a [`ChannelConfig`].
-    pub fn add_channel(mut self, config: ChannelConfig) -> WebRtcSocketBuilder<MultipleChannels> {
+    pub fn add_channel(mut self, config: ChannelConfig) -> WebRtcSocketBuilder {
         self.config.channels.push(config);
         self
     }
 
     /// Adds a new unreliable channel to the [`WebRtcSocket`] configuration.
-    pub fn add_unreliable_channel(mut self) -> WebRtcSocketBuilder<MultipleChannels> {
+    pub fn add_unreliable_channel(mut self) -> WebRtcSocketBuilder {
         self.config.channels.push(ChannelConfig::unreliable());
-        WebRtcSocketBuilder {
-            config: self.config,
-            channel_plurality: PhantomData,
-        }
+        self
     }
 
     /// Adds a new reliable channel to the [`WebRtcSocket`] configuration.
-    pub fn add_reliable_channel(mut self) -> WebRtcSocketBuilder<MultipleChannels> {
+    pub fn add_reliable_channel(mut self) -> WebRtcSocketBuilder {
         self.config.channels.push(ChannelConfig::reliable());
-        WebRtcSocketBuilder {
-            config: self.config,
-            channel_plurality: PhantomData,
-        }
+        self
     }
-}
 
-impl<C: BuildablePlurality> WebRtcSocketBuilder<C> {
     /// Creates a [`WebRtcSocket`] and the corresponding [`MessageLoopFuture`] according to the
     /// configuration supplied.
     ///
     /// The returned [`MessageLoopFuture`] should be awaited in order for messages to be sent and
     /// received.
-    pub fn build(self) -> (WebRtcSocket<C>, MessageLoopFuture) {
-        if self.config.channels.is_empty() {
-            unreachable!();
-        }
+    pub fn build(self) -> (WebRtcSocket, MessageLoopFuture) {
+        assert!(
+            !self.config.channels.is_empty(),
+            "Must have added at least one channel"
+        );
 
         let (peer_state_tx, peer_state_rx) = futures_channel::mpsc::unbounded();
 
@@ -315,7 +222,6 @@ impl<C: BuildablePlurality> WebRtcSocketBuilder<C> {
                 peer_state_rx,
                 peers: Default::default(),
                 channels,
-                channel_plurality: PhantomData,
             },
             Box::pin(socket_fut),
         )
@@ -393,13 +299,12 @@ impl WebRtcChannel {
 
 /// Contains a set of [`WebRtcChannel`]s and connection metadata.
 #[derive(Debug)]
-pub struct WebRtcSocket<C: ChannelPlurality = SingleChannel> {
+pub struct WebRtcSocket {
     id: once_cell::race::OnceBox<PeerId>,
     id_rx: futures_channel::oneshot::Receiver<PeerId>,
     peer_state_rx: futures_channel::mpsc::UnboundedReceiver<(PeerId, PeerState)>,
     peers: HashMap<PeerId, PeerState>,
     channels: Vec<Option<WebRtcChannel>>,
-    channel_plurality: PhantomData<C>,
 }
 
 impl WebRtcSocket {
@@ -419,9 +324,7 @@ impl WebRtcSocket {
     /// be sent and received.
     ///
     /// Please use the [`WebRtcSocketBuilder`] to create non-trivial sockets.
-    pub fn new_unreliable(
-        room_url: impl Into<String>,
-    ) -> (WebRtcSocket<SingleChannel>, MessageLoopFuture) {
+    pub fn new_unreliable(room_url: impl Into<String>) -> (WebRtcSocket, MessageLoopFuture) {
         WebRtcSocketBuilder::new(room_url)
             .add_channel(ChannelConfig::unreliable())
             .build()
@@ -434,16 +337,14 @@ impl WebRtcSocket {
     /// be sent and received.
     ///
     /// Please use the [`WebRtcSocketBuilder`] to create non-trivial sockets.
-    pub fn new_reliable(
-        room_url: impl Into<String>,
-    ) -> (WebRtcSocket<SingleChannel>, MessageLoopFuture) {
+    pub fn new_reliable(room_url: impl Into<String>) -> (WebRtcSocket, MessageLoopFuture) {
         WebRtcSocketBuilder::new(room_url)
             .add_channel(ChannelConfig::reliable())
             .build()
     }
 }
 
-impl<C: ChannelPlurality> WebRtcSocket<C> {
+impl WebRtcSocket {
     // Todo: Disconnect from the peer, severing all communication channels.
     // pub fn disconnect(&mut self, peer: PeerId) {}
 
@@ -651,39 +552,9 @@ impl<C: ChannelPlurality> WebRtcSocket<C> {
             .take()
             .ok_or(ChannelError::Taken)
     }
-}
 
-impl WebRtcSocket<SingleChannel> {
-    /// Call this where you want to handle new received messages.
-    ///
-    /// Messages are removed from the socket when called.
-    pub fn receive(&mut self) -> Vec<(PeerId, Packet)> {
-        self.channel_mut(0).receive()
-    }
-
-    /// Try to send a packet to the given peer. An error is propagated if the socket future
-    /// is dropped. `Ok` is not a guarantee of delivery.
-    pub fn try_send(&mut self, packet: Packet, peer: PeerId) -> Result<(), SendError> {
-        self.channel_mut(0).try_send(packet, peer)
-    }
-
-    /// Send a packet to the given peer. There is no guarantee of delivery.
-    ///
-    /// # Panics
-    /// Panics if socket future is dropped.
-    pub fn send(&mut self, packet: Packet, peer: PeerId) {
-        self.try_send(packet, peer).expect("Send failed");
-    }
-
-    /// Returns whether the socket channel is closed
-    pub fn is_closed(&self) -> bool {
-        self.channel(0).is_closed()
-    }
-}
-
-impl WebRtcSocket<MultipleChannels> {
     /// Returns whether any socket channel is closed
-    pub fn any_closed(&self) -> bool {
+    pub fn any_channel_closed(&self) -> bool {
         self.channels
             .iter()
             .filter_map(Option::as_ref)
@@ -691,7 +562,7 @@ impl WebRtcSocket<MultipleChannels> {
     }
 
     /// Returns whether all socket channels are closed
-    pub fn all_closed(&self) -> bool {
+    pub fn all_channels_closed(&self) -> bool {
         self.channels
             .iter()
             .filter_map(Option::as_ref)

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -583,14 +583,6 @@ impl WebRtcSocket {
     }
 }
 
-pub(crate) fn new_senders_and_receivers<T>(
-    channel_configs: &[ChannelConfig],
-) -> (Vec<UnboundedSender<T>>, Vec<UnboundedReceiver<T>>) {
-    (0..channel_configs.len())
-        .map(|_| futures_channel::mpsc::unbounded())
-        .unzip()
-}
-
 pub(crate) fn create_data_channels_ready_fut(
     channel_configs: &[ChannelConfig],
 ) -> (


### PR DESCRIPTION
The typestate pattern caused a lot of boilerplate w.r.t. both the implementation and the usage of matchbox socket.

There appeared to be only three actual uses of the typestate pattern:

* Preventing client code from calling build() without adding a channel.
* Some convenience methods to read/write from the first channel in the case where where was only one channel.
* Making sure that ggrs::NonBlockingSocket is only implemented for
  WebRtcSocket in the case where it is a single channel socket, to avoid the case where a reliable socket is accidentally used as a GGRS socket (or a unreliable socket is used for GGRS + some other data).

The first and (mostly) the last points can be accomplished at runtime via asserts, and owing to the "set it up and use it from one place" nature of this library I think it's highly unlikely that having a runtime assertion is problematic.

This is a breaking change owing to the removal of the SingleChannel-variant convenience methods, but it should be trivially easy to migrate by looking at modified example code.

---

This is definitely a "change based on personal taste", so I understand if your personal preferences do not align and you do not want to go down this route. But since I've gone to the trouble of writing this PR/micro-essay and you're reading it, well, you may as well keep reading, right? :)

TLDR: In my opinion, the benefits of the typestate pattern here are not justifying its cost.

As a new user approaching this library, one of my stumbling blocks was "_why_ is there this ChannelPlurality generic that's front and center?". Not "_what_ is it" - I understand the idea of making bad states unrepresentable, I'm already familiar with the typestate pattern in particular, I've used Rust plenty and I've shipped prod code with type wizardry in Scala, Typescript, etc - but rather the _why_, as in what motivates it.

So, I spent a while diving through the codebase to figure out what makes a single channel webrtc socket inherently different to a many channel socket in some way that makes it worth modeling it at a type system level - and after going through the exercise of removing the typestate pattern (I find editing code & following the compile errors a good way to understand it), all I really found was the convenience methods for a single channel WebRtcSocket - and (IMO) these more obscure how the library is structured than aid in understanding it.

So I figured I'd raise my changes as a PR to remove the typestate pattern and see what others thought - the result is at least less boilerplate-y.

I did read https://github.com/johanhelsing/matchbox/pull/160 to understand the thinking behind the initial introduction of the typestate pattern, and it seems to boil down to "let's make it easier for new users". I think that's a great goal, but I would argue that a somewhat-vaguely-named (and possibly misleading, at least for me) generic parameter is less easy (or at least, less simple) than embracing the concept of channels; the updated example code in this PR shows that dealing with a single channel is straightforward enough.

(I figure backwards compatibility may also have been a concern that motivated the introduction of the convenience methods I mentioned in my second bullet above? But I think the changes from dealing with channels are easy enough to adjust to - a single `.channel_mut(0)` in the (probably) 2 places where a single-channel user would be reading/writing from/to the socket would be the sum total of it.)

Closes: #332