### PR TITLE
channel split() method + async example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ dependencies = [
  "hashbrown 0.15.2",
  "paste",
  "static_assertions",
- "windows",
+ "windows 0.58.0",
  "windows-core",
 ]
 
@@ -119,7 +119,7 @@ checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "const-random",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -340,6 +340,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener 5.3.1",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +530,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_example"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-broadcast 0.7.2",
+ "console_error_panic_hook",
+ "console_log",
+ "futures",
+ "futures-timer",
+ "getrandom 0.3.2",
+ "js-sys",
+ "log",
+ "matchbox_socket",
+ "n0-future",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "tracing-wasm",
+ "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "web-time",
+]
+
+[[package]]
 name = "async_io_stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,7 +730,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d7d501eda01be6d500d843a06d9b9800c3f0fffaae3c29d17d9e4e172c28d37"
 dependencies = [
- "async-broadcast",
+ "async-broadcast 0.5.1",
  "async-fs",
  "async-lock",
  "atomicow",
@@ -1441,7 +1481,7 @@ checksum = "a0a48bad33c385a7818b7683a16c8b5c6930eded05cd3f176264fc1f5acea473"
 dependencies = [
  "ahash",
  "bevy_utils_proc_macros",
- "getrandom",
+ "getrandom 0.2.15",
  "hashbrown 0.14.5",
  "thread_local",
  "tracing",
@@ -1915,7 +1955,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "tiny-keccak",
 ]
@@ -1945,6 +1985,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1aaf9b65849a68662ac6c0810c8893a765c960b907dd7cfab9c4a50bf764fbc"
 dependencies = [
  "const_soft_float",
+]
+
+[[package]]
+name = "cordyceps"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec10f0a762d93c4498d2e97a333805cb6250d60bead623f71d8034f9a4152ba3"
+dependencies = [
+ "loom",
+ "tracing",
 ]
 
 [[package]]
@@ -2217,6 +2267,12 @@ dependencies = [
  "syn",
  "unicode-xid",
 ]
+
+[[package]]
+name = "diatomic-waker"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab03c107fafeb3ee9f5925686dbb7a73bc76e3932abb0d2b365cb64b169cf04c"
 
 [[package]]
 name = "digest"
@@ -2582,6 +2638,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-buffered"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe940397c8b744b9c2c974791c2c08bca2c3242ce0290393249e98f215a00472"
+dependencies = [
+ "cordyceps",
+ "diatomic-waker",
+ "futures-core",
+ "pin-project-lite",
+ "spin",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2695,6 +2764,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.48.0",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2724,7 +2806,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -2736,7 +2832,7 @@ checksum = "6961c572ec0692fd73a31f335db5e8b92b165c4d43e180ae0aaa64411d9baeb9"
 dependencies = [
  "bincode",
  "bitfield-rle",
- "getrandom",
+ "getrandom 0.2.15",
  "instant",
  "js-sys",
  "parking_lot",
@@ -2862,7 +2958,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 1.0.69",
- "windows",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -3337,9 +3433,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3454,6 +3550,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 dependencies = [
  "value-bag",
+]
+
+[[package]]
+name = "loom"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3645,8 +3754,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "n0-future"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399e11dc3b0e8d9d65b27170d22f5d779d52d9bed888db70d7e0c2c7ce3dfc52"
+dependencies = [
+ "cfg_aliases 0.2.1",
+ "derive_more",
+ "futures-buffered",
+ "futures-lite",
+ "futures-util",
+ "js-sys",
+ "pin-project",
+ "send_wrapper 0.6.0",
+ "tokio",
+ "tokio-util",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]
@@ -4396,6 +4526,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "radsort"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4428,7 +4564,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -4595,7 +4731,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -4797,6 +4933,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -5412,6 +5554,8 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
+ "hashbrown 0.14.5",
  "pin-project-lite",
  "tokio",
 ]
@@ -5751,12 +5895,22 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.2",
  "serde",
+ "uuid-rng-internal",
+]
+
+[[package]]
+name = "uuid-rng-internal"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9376f53b15ed85851c10175b5e45f0af556b4853ff3fe335080b337e3828981e"
+dependencies = [
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -5809,21 +5963,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.99"
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -5835,9 +5999,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5848,9 +6012,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5858,9 +6022,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5871,15 +6035,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6214,7 +6381,7 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
- "windows",
+ "windows 0.58.0",
  "windows-core",
 ]
 
@@ -6259,6 +6426,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "windows"
@@ -6580,6 +6756,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]

--- a/examples/async_example/.cargo/config.toml
+++ b/examples/async_example/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+runner = "wasm-server-runner"

--- a/examples/async_example/Cargo.toml
+++ b/examples/async_example/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "async_example"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+matchbox_socket = { path = "../../matchbox_socket" }
+
+futures-timer = { version = "3", features = ["wasm-bindgen"] }
+n0-future = { version = "0.1.2", features = [] }
+uuid = { version = "1.16", features = ["v4", "rng-getrandom"] }
+anyhow = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+web-time = "1.1.0"
+js-sys = "0.3.77"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+tracing = { version = "0.1" }
+async-broadcast = "0.7"
+log = "0.4"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+console_error_panic_hook = "0.1.7"
+console_log = "1.0"
+futures = { version = "0.3", default-features = false }
+wasm-bindgen-futures = "0.4.29"
+tokio = { version = "1.32", default-features = false, features = [
+  "time",
+  "sync",
+] }
+getrandom = { version = "0.3", features = ["wasm_js"] }
+tracing-wasm = "0.2.1"
+wasm-bindgen = "0.2"
+web-sys = { version = "0.3", features = ["Window", "Location"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+futures = "0.3"
+tokio = "1.32"

--- a/examples/async_example/src/main.rs
+++ b/examples/async_example/src/main.rs
@@ -1,0 +1,150 @@
+use futures::{FutureExt, SinkExt, StreamExt, channel::mpsc::UnboundedSender, select};
+use futures_timer::Delay;
+use matchbox_socket::{Packet, PeerId, PeerState, WebRtcSocket};
+use n0_future::task::{AbortOnDropHandle, spawn};
+use std::{collections::BTreeMap, time::Duration};
+use tracing::info;
+
+const CHANNEL_ID: usize = 0;
+
+fn get_timestamp() -> u128 {
+    web_time::SystemTime::now()
+        .duration_since(web_time::UNIX_EPOCH)
+        .unwrap()
+        .as_micros()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn main() {
+    // Setup logging
+    console_error_panic_hook::set_once();
+    console_log::init_with_level(log::Level::Debug).unwrap();
+
+    wasm_bindgen_futures::spawn_local(async_main());
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::main]
+async fn main() {
+    // Setup logging
+    use tracing_subscriber::prelude::*;
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "async_example=info,matchbox_socket=info".into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    async_main().await
+}
+
+async fn async_main() {
+    let (mut socket, loop_fut) = WebRtcSocket::new_reliable("ws://localhost:3536/");
+
+    let loop_fut = loop_fut.fuse();
+    futures::pin_mut!(loop_fut);
+
+    let timeout = Delay::new(Duration::from_millis(100));
+    futures::pin_mut!(timeout);
+
+    let (tx, rx) = socket.take_channel(CHANNEL_ID).unwrap().split();
+    let (mut broadcast_tx, mut broadcast_rx) = async_broadcast::broadcast::<(PeerId, Packet)>(1024);
+    broadcast_tx.set_overflow(true);
+    broadcast_rx.set_overflow(true);
+    let broadcast_rx = broadcast_rx.deactivate();
+    let _broadcast_task = spawn(async move {
+        futures::pin_mut!(rx);
+        while let Some((peer, packet)) = rx.next().await {
+            broadcast_tx.broadcast((peer, packet)).await.unwrap();
+        }
+    });
+
+    let mut tasks = BTreeMap::new();
+
+    loop {
+        // Handle any new peers
+        for (peer, state) in socket.update_peers() {
+            match state {
+                PeerState::Connected => {
+                    info!("Peer joined: {peer}");
+                    let tx = tx.clone();
+                    let rx = broadcast_rx.activate_cloned();
+                    tasks.insert(
+                        peer,
+                        AbortOnDropHandle::new(n0_future::task::spawn(socket_task(peer, tx, rx))),
+                    );
+                }
+                PeerState::Disconnected => {
+                    info!("Peer left: {peer}");
+                    tasks.remove(&peer);
+                }
+            }
+        }
+
+        select! {
+            // Restart this loop every 100ms
+            _ = (&mut timeout).fuse() => {
+                timeout.reset(Duration::from_millis(100));
+            }
+
+            // Or break if the message loop ends (disconnected, closed, etc.)
+            _ = &mut loop_fut => {
+                break;
+            }
+        }
+    }
+    tasks.clear();
+}
+
+async fn socket_task(
+    peer: PeerId,
+    tx: UnboundedSender<(PeerId, Packet)>,
+    mut rx: async_broadcast::Receiver<(PeerId, Packet)>,
+) {
+    let mut writer = tx.clone();
+    let _ping_task = spawn(async move {
+        for _i in 0..10 {
+            n0_future::time::sleep(Duration::from_secs_f32(1.5)).await;
+            if _i == 0 {
+                writer
+                    .send((peer, b"hello friend!".to_vec().into()))
+                    .await
+                    .unwrap();
+            }
+            writer
+                .send((
+                    peer,
+                    format!("ping {}", get_timestamp())
+                        .as_bytes()
+                        .to_vec()
+                        .into(),
+                ))
+                .await
+                .unwrap();
+        }
+    });
+    let mut writer = tx.clone();
+    let _pong_task = spawn(async move {
+        while let Ok((packet_peer, packet)) = rx.recv().await {
+            if packet_peer != peer {
+                continue;
+            }
+            let message = String::from_utf8_lossy(&packet);
+            if message.starts_with("ping") {
+                let ts = message.split(" ").nth(1).unwrap().parse::<u128>().unwrap();
+                let packet = format!("pong {}", ts).as_bytes().to_vec();
+                writer.send((peer, packet.into())).await.unwrap();
+            } else if message.starts_with("pong") {
+                let ts = message.split(" ").nth(1).unwrap().parse::<u128>().unwrap();
+                let now = get_timestamp();
+                let diff = now - ts;
+                info!("Ping from {peer} took {}ms", diff as f32 / 1000.0);
+            } else {
+                info!("Message from {peer}: \n\n {message:?} \n");
+            }
+        }
+    });
+    _ping_task.await.unwrap();
+    _pong_task.await.unwrap();
+}

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -271,6 +271,17 @@ pub struct WebRtcChannel {
 }
 
 impl WebRtcChannel {
+    /// Split the channel into a reader and writer.
+    /// Useful for concurrently sending and receiving messages using async code.
+    pub fn split(
+        self,
+    ) -> (
+        UnboundedSender<(PeerId, Packet)>,
+        UnboundedReceiver<(PeerId, Packet)>,
+    ) {
+        (self.tx, self.rx)
+    }
+
     /// Returns the [`ChannelConfig`] used to create this channel.
     pub fn config(&self) -> &ChannelConfig {
         &self.config

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -282,6 +282,12 @@ impl WebRtcChannel {
         (self.tx, self.rx)
     }
 
+    /// Clone a sender for this channel.
+    /// Useful for sending messages to the same channel from multiple threads/async tasks.
+    pub fn sender_clone(&self) -> UnboundedSender<(PeerId, Packet)> {
+        self.tx.clone()
+    }
+
     /// Returns the [`ChannelConfig`] used to create this channel.
     pub fn config(&self) -> &ChannelConfig {
         &self.config

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -495,6 +495,18 @@ impl WebRtcSocket {
     }
 }
 
+impl Stream for WebRtcSocket {
+    type Item = (PeerId, PeerState);
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let mut peer_state_rx = Pin::new(&mut self.get_mut().peer_state_rx);
+        peer_state_rx.as_mut().poll_next(cx)
+    }
+}
+
 impl WebRtcSocket {
     // Todo: Disconnect from the peer, severing all communication channels.
     // pub fn disconnect(&mut self, peer: PeerId) {}


### PR DESCRIPTION
close https://github.com/johanhelsing/matchbox/issues/482

Adds method to obtain the channels that make up a WebRTC channel. Without this, you cannot read and write concurrently using async.

```rs
impl WebRtcChannel {
    /// Split the channel into a reader and writer.
    /// Useful for concurrently sending and receiving messages using async code.
    pub fn split(
        self,
    ) -> (
        UnboundedSender<(PeerId, Packet)>,
        UnboundedReceiver<(PeerId, Packet)>,
    ) {
        (self.tx, self.rx)
    }


```

Adds simple example showcasing full mesh ping pong spam.


Through, now I think of it a bit more, you don't even need an async sender, the channels are unbounded, so you can send everything using only sync, and read everything using async. Still, without extra methods, you can't clone out the sender and put it on a different thread/async task.