### PR TITLE
Remove tokio-util for WASM targets

### DIFF
--- a/matchbox_socket/Cargo.toml
+++ b/matchbox_socket/Cargo.toml
@@ -40,7 +40,6 @@ once_cell = { version = "1.17", default-features = false, features = [
   "alloc",
 ] }
 derive_more = { version = "1.0", features = ["display", "from"] }
-tokio-util = { version = "0.7", features = ["io", "compat"] }
 
 ggrs = { version = "0.11", default-features = false, optional = true }
 bincode = { version = "1.3", default-features = false, optional = true }
@@ -82,6 +81,7 @@ async-tungstenite = { version = "0.28", default-features = false, features = [
 ] }
 webrtc = { version = "0.12", default-features = false }
 async-compat = { version = "0.2", default-features = false }
+tokio-util = { version = "0.7", features = ["io", "compat"] }
 
 [dev-dependencies]
 futures-test = "0.3"

--- a/matchbox_socket/src/webrtc_socket/socket.rs
+++ b/matchbox_socket/src/webrtc_socket/socket.rs
@@ -15,6 +15,7 @@ use futures_channel::mpsc::{SendError, TrySendError, UnboundedReceiver, Unbounde
 use log::{debug, error};
 use matchbox_protocol::PeerId;
 use std::{collections::HashMap, future::ready, pin::Pin, task::Poll, time::Duration};
+#[cfg(not(target_arch = "wasm32"))]
 use tokio_util::{
     compat::TokioAsyncWriteCompatExt,
     io::{CopyToBytes, SinkWriter},
@@ -697,6 +698,7 @@ impl WebRtcSocket {
         self.take_channel(pos)
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     /// Converts the [`WebRtcChannel`] of a given [`PeerId`] into a [`RawPeerChannel`].
     pub fn take_raw_by_id(
         &mut self,
@@ -836,6 +838,7 @@ async fn run_socket(
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn compat_read_write(
     remote: PeerId,
     stream: UnboundedReceiver<(PeerId, Packet)>,


### PR DESCRIPTION
Disabled `take_raw_by_id` for WASM targets, since mio seems to be pulled in by tokio-util which is not WASM compatible