### PR TITLE
Fix `bevy_matchbox` doc test & include doc tests in CI

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Run cargo test
         run: cargo test --features signaling --all-targets
 
+      - name: Run cargo doc tests
+        run: cargo test --doc
+
   # Should be upgraded to test when possible
   check-wasm:
     name: Check Wasm

--- a/bevy_matchbox/src/socket.rs
+++ b/bevy_matchbox/src/socket.rs
@@ -26,7 +26,7 @@ use std::{
 ///     mut commands: Commands,
 ///     socket: Query<Entity, With<MatchboxSocket>>
 /// ) {
-///     let socket = socket.single();
+///     let socket = socket.single().unwrap();
 ///     commands.entity(socket).despawn();
 /// }
 /// ```

--- a/bevy_matchbox/src/socket.rs
+++ b/bevy_matchbox/src/socket.rs
@@ -24,9 +24,9 @@ use std::{
 ///
 /// fn close_socket_system(
 ///     mut commands: Commands,
-///     socket: Query<Entity, With<MatchboxSocket>>
+///     socket: Single<Entity, With<MatchboxSocket>>
 /// ) {
-///     let socket = socket.single().unwrap();
+///     let socket = socket.into_inner();
 ///     commands.entity(socket).despawn();
 /// }
 /// ```

--- a/examples/async_example/src/main.rs
+++ b/examples/async_example/src/main.rs
@@ -140,7 +140,7 @@ async fn socket_task(peer: PeerId, tx: Sender<Packet>, mut rx: Receiver<Packet>)
             let message = String::from_utf8_lossy(&packet);
             if message.starts_with("ping") {
                 let ts = message.split(" ").nth(1).unwrap().parse::<u128>().unwrap();
-                let packet = format!("pong {}", ts).as_bytes().to_vec();
+                let packet = format!("pong {ts}").as_bytes().to_vec();
                 writer.send(packet.into()).await.unwrap();
             } else if message.starts_with("pong") {
                 let ts = message.split(" ").nth(1).unwrap().parse::<u128>().unwrap();

--- a/examples/bevy_ggrs/src/box_game.rs
+++ b/examples/bevy_ggrs/src/box_game.rs
@@ -207,9 +207,9 @@ pub fn move_cube_system(
         t.translation.z += v.z * dt;
 
         // constrain cube to plane
-        t.translation.x = t.translation.x.max(-1. * (PLANE_SIZE - CUBE_SIZE) * 0.5);
+        t.translation.x = t.translation.x.max(-(PLANE_SIZE - CUBE_SIZE) * 0.5);
         t.translation.x = t.translation.x.min((PLANE_SIZE - CUBE_SIZE) * 0.5);
-        t.translation.z = t.translation.z.max(-1. * (PLANE_SIZE - CUBE_SIZE) * 0.5);
+        t.translation.z = t.translation.z.max(-(PLANE_SIZE - CUBE_SIZE) * 0.5);
         t.translation.z = t.translation.z.min((PLANE_SIZE - CUBE_SIZE) * 0.5);
     }
 }

--- a/examples/custom_signaller/src/main.rs
+++ b/examples/custom_signaller/src/main.rs
@@ -102,10 +102,7 @@ async fn async_main(node_id: Option<String>) {
             let message = String::from_utf8_lossy(&packet);
             if message.contains("ping") {
                 let ts = message.split(" ").nth(1).unwrap().parse::<u128>().unwrap();
-                let packet = format!("pong {}", ts)
-                    .as_bytes()
-                    .to_vec()
-                    .into_boxed_slice();
+                let packet = format!("pong {ts}").as_bytes().to_vec().into_boxed_slice();
                 socket.channel_mut(CHANNEL_ID).send(packet, peer);
             }
             if message.contains("pong") {


### PR DESCRIPTION
This PR addresses the following:

* Fixes a failing doc test in `bevy_matchbox`: The api of `single()` now returns a `Result<>` instead of panicking.
* Enables doc test execution in CI to ensure that any future regressions in code examples within the documentation are caught automatically by CI, preventing outdated or broken examples from being published.
* Fixes clippy lints triggered by CI