### PR TITLE
feat: Add `flecs_matchbox` integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,6 +1626,29 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.9.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.101",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
@@ -1826,6 +1849,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2000,6 +2032,20 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2686,6 +2732,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2813,6 +2882,56 @@ checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flecs_ecs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40445da19883917cbbb7f717f6140a2d1f851bba3f76c4c9cc321292b3b1351a"
+dependencies = [
+ "bitflags 2.9.1",
+ "compact_str",
+ "flecs_ecs_derive",
+ "flecs_ecs_sys",
+ "fxhash",
+]
+
+[[package]]
+name = "flecs_ecs_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980c979fff7697e6f43562e10e6371470614f8dd27a0b5e60d335fae838ac2dd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "flecs_ecs_sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa3506032735c66dd0a51e6eafea1f442e0b56c2c567c1e207d83a235670875"
+dependencies = [
+ "bindgen 0.69.5",
+ "cc",
+ "libc",
+ "regex",
+]
+
+[[package]]
+name = "flecs_matchbox"
+version = "0.1.0"
+dependencies = [
+ "async-compat",
+ "cfg-if",
+ "env_logger",
+ "flecs_ecs",
+ "futures-lite",
+ "log",
+ "matchbox_signaling",
+ "matchbox_socket",
 ]
 
 [[package]]
@@ -3049,6 +3168,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -3473,6 +3601,15 @@ name = "hmac-sha256"
 version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad6880c8d4a9ebf39c6e8b77007ce223f646a4d21ce29d99f70cb16420545425"
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "hostname-validator"
@@ -4096,6 +4233,15 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -4117,6 +4263,30 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "jni"
@@ -4200,6 +4370,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -7199,7 +7375,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528bdd1f0e27b5dd9a4ededf154e824b0532731e4af73bb531de46276e0aab1e"
 dependencies = [
- "bindgen",
+ "bindgen 0.70.1",
  "cc",
  "cfg-if",
  "once_cell",
@@ -8005,6 +8181,18 @@ dependencies = [
  "log",
  "serde",
  "web-sys",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "bevy_matchbox",
+  "flecs_matchbox",
   "matchbox_protocol",
   "matchbox_socket",
   "matchbox_server",

--- a/flecs_matchbox/Cargo.toml
+++ b/flecs_matchbox/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "flecs_matchbox"
+version = "0.1.0"
+authors = [
+    "Johan Helsing <johanhelsing@gmail.com>",
+    "nomaterials <nomaterials@gmail.com>",
+]
+edition = "2021"
+description = "A flecs integration for the matchbox WebRTC networking library"
+license = "MIT OR Apache-2.0"
+keywords = ["flecs", "webrtc", "peer-to-peer", "networking", "wasm"]
+categories = [
+    "network-programming",
+    "game-development",
+    "wasm",
+    "web-programming",
+]
+repository = "https://github.com/johanhelsing/matchbox"
+homepage = "https://github.com/johanhelsing/matchbox"
+readme = "README.md"
+
+[features]
+default = []
+signaling = ["dep:matchbox_signaling", "dep:async-compat"]
+
+[dependencies]
+flecs_ecs = "0.1.1" 
+matchbox_socket = { version = "0.12.0", path = "../matchbox_socket" }
+cfg-if = "1.0"
+futures-lite = "2.3.0"
+log = "0.4.21"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+matchbox_signaling = { version = "0.12.0", path = "../matchbox_signaling", optional = true }
+async-compat = { version = "0.2.2", optional = true }
+
+[dev-dependencies]
+env_logger = "0.11.3"
+
+[[example]]
+name = "hello"
+
+[[example]]
+name = "hello_host"
+required-features = ["signaling"]
+
+[[example]]
+name = "hello_signaling"
+required-features = ["signaling"]

--- a/flecs_matchbox/README.md
+++ b/flecs_matchbox/README.md
@@ -1,0 +1,7 @@
+# flecs_matchbox
+
+A [`Flecs-Rust`](https://github.com/Indra-db/Flecs-Rust) integration for the `matchbox` WebRTC networking library.
+
+This crate provides a simple, resource-based API to add peer-to-peer WebRTC networking to your `Flecs-Rust` application, making it easy to create web-based multiplayer games and applications.
+
+It is heavily inspired by the [`bevy_matchbox`](https://github.com/johanhelsing/matchbox/tree/main/bevy_matchbox) crate and follows its API design closely.

--- a/flecs_matchbox/examples/hello.rs
+++ b/flecs_matchbox/examples/hello.rs
@@ -1,0 +1,66 @@
+//! A simple example of using flecs_matchbox.
+//!
+//! Run with `cargo run --example hello`.
+//! You will need to have a `matchbox_server` running.
+
+use flecs_ecs::prelude::*;
+use flecs_matchbox::prelude::*;
+use log::{error, info};
+
+const CHANNEL_ID: usize = 0;
+
+fn main() {
+    env_logger::init();
+
+    info!("Starting flecs_matchbox hello example");
+
+    let world = World::new();
+
+    let _ = world.entity_named("Socket").set({
+        info!("Opening socket...");
+        let room_url = "ws://localhost:3536/hello_flecs";
+        FlecsMatchboxSocket::new_reliable(room_url)
+    });
+
+    // Add systems to run during the main loop
+    world
+        .system::<&mut FlecsMatchboxSocket>()
+        .each(handle_connections_and_messages);
+
+    world
+        .system::<&mut FlecsMatchboxSocket>()
+        .set_interval(5.0)
+        .each(send_message);
+
+    // Run the world
+    loop {
+        world.progress();
+    }
+}
+
+fn send_message(socket: &mut FlecsMatchboxSocket) {
+    let peers: Vec<_> = socket.connected_peers().collect();
+    info!("Sending message to connected peers: {peers:?}");
+    for peer in peers {
+        let packet = "hello from flecs!".as_bytes().to_vec();
+        socket.channel_mut(CHANNEL_ID).send(packet.into(), peer);
+    }
+}
+
+fn handle_connections_and_messages(socket: &mut FlecsMatchboxSocket) {
+    // Check for new connections
+    for (peer, state) in socket.update_peers() {
+        match state {
+            PeerState::Connected => info!("Peer Connected: {peer}"),
+            PeerState::Disconnected => info!("Peer Disconnected: {peer}"),
+        }
+    }
+
+    // Handle incoming messages
+    for (peer, message) in socket.channel_mut(CHANNEL_ID).receive() {
+        match std::str::from_utf8(&message) {
+            Ok(text) => info!("Received message from {peer}: {text}"),
+            Err(e) => error!("Failed to decode message from {peer}: {e}"),
+        }
+    }
+}

--- a/flecs_matchbox/examples/hello_host.rs
+++ b/flecs_matchbox/examples/hello_host.rs
@@ -1,0 +1,81 @@
+//! An example of running a client and an embedded signaling server in the same process.
+//! This is useful for local testing or for "listen server" style games.
+//!
+//! Run with `cargo run --example hello_host --features signaling`.
+
+use flecs_ecs::prelude::*;
+use flecs_matchbox::prelude::*;
+use log::{error, info};
+use matchbox_signaling::SignalingServer;
+use std::net::{Ipv4Addr, SocketAddrV4};
+
+const CHANNEL_ID: usize = 0;
+
+fn main() {
+    env_logger::init();
+    info!("Starting flecs_matchbox hello_host example");
+
+    let mut world = World::new();
+
+    // Start the server
+    let addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 3536);
+    world.start_server(
+        SignalingServer::client_server_builder(addr)
+            .on_connection_request(|connection| {
+                info!("Connecting: {connection:?}");
+                Ok(true) // Allow all connections
+            })
+            .on_id_assignment(|(socket, id)| info!("{socket} received {id}"))
+            .on_host_connected(|id| info!("Host joined: {id}"))
+            .on_host_disconnected(|id| info!("Host left: {id}"))
+            .on_client_connected(|id| info!("Client joined: {id}"))
+            .on_client_disconnected(|id| info!("Client left: {id}"))
+            .cors()
+            .trace(),
+    );
+
+    // Start the client
+    let _ = world.entity_named("Socket").set({
+        info!("Opening socket...");
+        let room_url = "ws://localhost:3536/hello_flecs";
+        FlecsMatchboxSocket::new_reliable(room_url)
+    });
+
+    world
+        .system::<&mut FlecsMatchboxSocket>()
+        .each(handle_connections_and_messages);
+
+    world
+        .system::<&mut FlecsMatchboxSocket>()
+        .set_interval(5.0)
+        .each(send_message);
+
+    // Run the world
+    loop {
+        world.progress();
+    }
+}
+
+fn send_message(socket: &mut FlecsMatchboxSocket) {
+    let peers: Vec<_> = socket.connected_peers().collect();
+    info!("(Host) Sending message to connected peers: {peers:?}");
+    for peer in peers {
+        let packet = "hello from your host!".as_bytes().to_vec();
+        socket.channel_mut(CHANNEL_ID).send(packet.into(), peer);
+    }
+}
+
+fn handle_connections_and_messages(socket: &mut FlecsMatchboxSocket) {
+    // Check for new connections
+    for (peer, state) in socket.update_peers() {
+        info!("(Host) Peer {peer} changed state to {state:?}");
+    }
+
+    // Handle incoming messages
+    for (peer, message) in socket.channel_mut(CHANNEL_ID).receive() {
+        match std::str::from_utf8(&message) {
+            Ok(text) => info!("(Host)Received message from {peer}: {text}"),
+            Err(e) => error!("Failed to decode message from {peer}: {e}"),
+        }
+    }
+}

--- a/flecs_matchbox/examples/hello_signaling.rs
+++ b/flecs_matchbox/examples/hello_signaling.rs
@@ -1,0 +1,36 @@
+//! An example of running just a signaling server as a headless flecs app.
+//!
+//! Run with `cargo run --example hello_signaling --features signaling`.
+
+use flecs_ecs::prelude::*;
+use flecs_matchbox::prelude::*;
+use log::info;
+use matchbox_signaling::SignalingServer;
+use std::net::{Ipv4Addr, SocketAddrV4};
+
+fn main() {
+    env_logger::init();
+    info!("Starting flecs_matchbox signaling server example");
+
+    let mut world = World::new();
+
+    let addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 3536);
+    world.start_server(
+        SignalingServer::client_server_builder(addr)
+            .on_connection_request(|connection| {
+                info!("Connecting: {connection:?}");
+                Ok(true) // Allow all connections
+            })
+            .on_id_assignment(|(socket, id)| info!("{socket} received {id}"))
+            .on_host_connected(|id| info!("Host joined: {id}"))
+            .on_host_disconnected(|id| info!("Host left: {id}"))
+            .on_client_connected(|id| info!("Client joined: {id}"))
+            .on_client_disconnected(|id| info!("Client left: {id}"))
+            .cors()
+            .trace(),
+    );
+
+    loop {
+        world.progress();
+    }
+}

--- a/flecs_matchbox/src/lib.rs
+++ b/flecs_matchbox/src/lib.rs
@@ -1,0 +1,29 @@
+#![warn(missing_docs)]
+#![doc = "A flecs-rust integration for the matchbox WebRTC networking library, inspired by bevy_matchbox."]
+#![forbid(unsafe_code)]
+
+use cfg_if::cfg_if;
+
+mod socket;
+pub use socket::*;
+
+cfg_if! {
+    if #[cfg(all(not(target_arch = "wasm32"), feature = "signaling"))] {
+        mod signaling;
+        pub use signaling::*;
+    }
+}
+
+/// use `flecs_matchbox::prelude::*;` to import common types and traits.
+pub mod prelude {
+    pub use crate::{CloseSocketExt, FlecsMatchboxSocket, OpenSocketExt};
+    use cfg_if::cfg_if;
+    pub use matchbox_socket::{ChannelConfig, PeerId, PeerState, WebRtcSocketBuilder};
+
+    cfg_if! {
+        if #[cfg(all(not(target_arch = "wasm32"), feature = "signaling"))] {
+            pub use crate::signaling::{FlecsMatchboxServer, StartServerExt, StopServerExt};
+            pub use matchbox_signaling::SignalingServerBuilder;
+        }
+    }
+}

--- a/flecs_matchbox/src/signaling.rs
+++ b/flecs_matchbox/src/signaling.rs
@@ -1,0 +1,77 @@
+//! A wrapper for `matchbox_signaling::SignalingServer` for use in Flecs.
+//! This module is only available on native targets with the `signaling` feature enabled.
+
+use async_compat::CompatExt;
+use flecs_ecs::prelude::*;
+use log::{error, info};
+use matchbox_signaling::{
+    Error, SignalingCallbacks, SignalingServer, SignalingServerBuilder, SignalingState,
+};
+use std::thread::JoinHandle;
+
+/// A [`SignalingServer`] wrapped for use as a Flecs singleton component.
+/// When this component is added, it will spawn a background thread to run the server.
+#[derive(Component)]
+#[allow(dead_code)] // task is kept alive to not drop it
+pub struct FlecsMatchboxServer(JoinHandle<Result<(), Error>>);
+
+impl<Topology, Cb, S> From<SignalingServerBuilder<Topology, Cb, S>> for FlecsMatchboxServer
+where
+    Topology: matchbox_signaling::topologies::SignalingTopology<Cb, S>,
+    Cb: SignalingCallbacks,
+    S: SignalingState,
+{
+    fn from(builder: SignalingServerBuilder<Topology, Cb, S>) -> Self {
+        Self::from(builder.build())
+    }
+}
+
+impl From<SignalingServer> for FlecsMatchboxServer {
+    fn from(server: SignalingServer) -> Self {
+        let task = std::thread::spawn(move || {
+            info!("Signaling server started");
+            let result = futures_lite::future::block_on(server.serve().compat());
+            if let Err(e) = &result {
+                error!("Signaling server ended with error: {e:?}");
+            }
+            info!("Signaling server finished");
+            result
+        });
+        FlecsMatchboxServer(task)
+    }
+}
+
+/// An extension trait for `flecs_ecs::prelude::World` to simplify starting a signaling server.
+pub trait StartServerExt<
+    Topology: matchbox_signaling::topologies::SignalingTopology<Cb, S>,
+    Cb: SignalingCallbacks,
+    S: SignalingState,
+>
+{
+    /// Starts a [`FlecsMatchboxServer`] and adds it as a singleton.
+    fn start_server(&mut self, builder: SignalingServerBuilder<Topology, Cb, S>);
+}
+
+impl<Topology, Cb, S> StartServerExt<Topology, Cb, S> for World
+where
+    Topology: matchbox_signaling::topologies::SignalingTopology<Cb, S> + Send + 'static,
+    Cb: SignalingCallbacks,
+    S: SignalingState,
+{
+    fn start_server(&mut self, builder: SignalingServerBuilder<Topology, Cb, S>) {
+        let server = FlecsMatchboxServer::from(builder);
+        self.set(server);
+    }
+}
+
+/// An extension trait for `flecs_ecs::prelude::World` to simplify stopping a signaling server.
+pub trait StopServerExt {
+    /// Removes the [`FlecsMatchboxServer`] singleton, stopping the server.
+    fn stop_server(&mut self);
+}
+
+impl StopServerExt for World {
+    fn stop_server(&mut self) {
+        self.remove::<FlecsMatchboxServer>();
+    }
+}

--- a/flecs_matchbox/src/socket.rs
+++ b/flecs_matchbox/src/socket.rs
@@ -1,0 +1,90 @@
+//! The core `FlecsMatchboxSocket` and related extension traits.
+
+use flecs_ecs::prelude::*;
+use futures_lite::future::block_on;
+use log::info;
+pub use matchbox_socket;
+use matchbox_socket::{MessageLoopFuture, WebRtcSocket, WebRtcSocketBuilder};
+use std::ops::{Deref, DerefMut};
+
+/// A [`WebRtcSocket`] wrapped for use as a Flecs singleton component.
+///
+/// When this component is created, it will spawn a background task to run the
+/// socket's message loop. When the component is removed from the world (or the
+/// world is dropped), the underlying socket will be dropped, and the background
+/// task will terminate.
+///
+/// Create one using [`WebRtcSocketBuilder`] and `.into()` or `::from()`, or use the
+/// [`OpenSocketExt`] trait on `&mut World`.
+#[derive(Component)]
+pub struct FlecsMatchboxSocket(WebRtcSocket);
+
+impl Deref for FlecsMatchboxSocket {
+    type Target = WebRtcSocket;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for FlecsMatchboxSocket {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<WebRtcSocketBuilder> for FlecsMatchboxSocket {
+    fn from(builder: WebRtcSocketBuilder) -> Self {
+        Self::from(builder.build())
+    }
+}
+
+impl From<(WebRtcSocket, MessageLoopFuture)> for FlecsMatchboxSocket {
+    fn from((socket, message_loop_fut): (WebRtcSocket, MessageLoopFuture)) -> Self {
+        std::thread::spawn(move || {
+            info!("Matchbox message loop started");
+            if let Err(e) = block_on(message_loop_fut) {
+                log::error!("Message loop ended with error: {e:?}");
+            }
+            info!("Matchbox message loop finished");
+        });
+        FlecsMatchboxSocket(socket)
+    }
+}
+
+/// An extension trait for `flecs_ecs::prelude::World` to simplify opening sockets.
+pub trait OpenSocketExt {
+    /// Creates a [`FlecsMatchboxSocket`] from a builder and adds it as a singleton.
+    fn open_socket(&mut self, socket_builder: WebRtcSocketBuilder);
+}
+
+impl OpenSocketExt for World {
+    fn open_socket(&mut self, socket_builder: WebRtcSocketBuilder) {
+        let socket = FlecsMatchboxSocket::from(socket_builder);
+        self.set(socket);
+    }
+}
+
+/// An extension trait for `flecs_ecs::prelude::World` to simplify closing sockets.
+pub trait CloseSocketExt {
+    /// Removes the [`FlecsMatchboxSocket`] singleton, closing the connection.
+    fn close_socket(&mut self);
+}
+
+impl CloseSocketExt for World {
+    fn close_socket(&mut self) {
+        self.remove::<FlecsMatchboxSocket>();
+    }
+}
+
+impl FlecsMatchboxSocket {
+    /// Create a new socket with a single unreliable channel.
+    pub fn new_unreliable(room_url: impl Into<String>) -> Self {
+        Self::from(WebRtcSocket::new_unreliable(room_url))
+    }
+
+    /// Create a new socket with a single reliable channel.
+    pub fn new_reliable(room_url: impl Into<String>) -> Self {
+        Self::from(WebRtcSocket::new_reliable(room_url))
+    }
+}


### PR DESCRIPTION
This PR introduces `flecs_matchbox`, a new integration crate for the [Flecs](https://github.com/SanderMertens/flecs) Entity Component System, a high-performance C/C++ ECS with excellent [Rust bindings](https://github.com/Indra-db/Flecs-Rust).

The API is designed to be consistent with `bevy_matchbox`, offering a familiar developer experience. It provides:

* A `FlecsMatchboxSocket` component that is managed as a singleton.

* `OpenSocketExt` and `CloseSocketExt` traits on the Flecs World for ergonomic setup and teardown.

* An optional `signaling` feature for an embedded server on native builds.

The crate includes a suite of examples (`hello`, `hello_host`, `hello_signaling`) that mirror the existing `bevy_matchbox` examples to ensure correctness and demonstrate usage.