### PR TITLE
[WIP] Add support for wasm32-wasip2 target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.wasm32-unknown-unknown]
+runner = "wasm-bindgen-test-runner"
+
+[target.wasm32-wasip2]
+runner = "wasmtime"

--- a/matchbox_socket/Cargo.toml
+++ b/matchbox_socket/Cargo.toml
@@ -49,7 +49,7 @@ bincode = { version = "2.0", default-features = false, features = [
 ], optional = true }
 bytes = { version = "1.1", default-features = false }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 ggrs = { version = "0.11", default-features = false, optional = true, features = [
   "wasm-bindgen",
 ] }
@@ -78,7 +78,7 @@ web-sys = { version = "0.3.22", default-features = false, features = [
 ] }
 serde-wasm-bindgen = "0.6"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(any(not(target_family = "wasm"), all(target_os = "wasi", target_env = "p2")))'.dependencies]
 async-tungstenite = { version = "0.29", default-features = false, features = [
   "async-std-runtime",
   "async-tls",

--- a/matchbox_socket/src/webrtc_socket/error.rs
+++ b/matchbox_socket/src/webrtc_socket/error.rs
@@ -39,12 +39,15 @@ pub enum SignalingError {
     NegotiationFailed(#[from] Box<SignalingError>),
 
     /// Native
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(any(
+        not(target_family = "wasm"),
+        all(target_os = "wasi", target_env = "p2")
+    ))]
     #[error("socket failure communicating with signaling server: {0}")]
     WebSocket(#[from] async_tungstenite::tungstenite::Error),
 
     /// WASM
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     #[error("socket failure communicating with signaling server: {0}")]
     WebSocket(#[from] ws_stream_wasm::WsErr),
 
@@ -55,7 +58,7 @@ pub enum SignalingError {
 }
 
 cfg_if! {
-    if #[cfg(target_arch = "wasm32")] {
+    if #[cfg(all(target_family = "wasm", target_os = "unknown"))] {
         use wasm_bindgen::{JsValue};
         use derive_more::Display;
 


### PR DESCRIPTION
This will not work until the following upstream changes happen:

- [ ] `std` needs to expose what's needed by `tokio`'s `"net"` feature: https://github.com/rust-lang/rust/issues/130323#issuecomment-2350379144
- [ ] `tokio` needs to support the `wasm32-wasip2` target: https://github.com/tokio-rs/mio/pull/1836 + https://github.com/tokio-rs/tokio/pull/6893 (as it stands, even if this PR is merged, it'll only work on nightly Rust...)
- [ ] `webrtc` / `webrtc-*` crates need to support the `wasm32-wasip2` target: https://github.com/webrtc-rs/webrtc/discussions/394#discussioncomment-14033978