### PR TITLE
Docs for webrtc_socket/messages.rs

### DIFF
--- a/matchbox_socket/src/webrtc_socket/messages.rs
+++ b/matchbox_socket/src/webrtc_socket/messages.rs
@@ -19,19 +19,18 @@ pub type PeerRequest = matchbox_protocol::PeerRequest<PeerSignal>;
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub enum PeerSignal {
     /// [Ice (Interactive Connectivity Establishment) Candidate](https://en.wikipedia.org/wiki/Interactive_Connectivity_Establishment).
-    ///
-    /// JSON encoding of an [`RTCIceCandidate`](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate).
-    ///
-    /// Note that while [`RTCIceCandidate`](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate/RTCIceCandidate)'s
-    /// constructor accepts a string for legacy purposes, that is not how this is being used: this
-    /// is instead a
-    /// [JSON encoding of the of the `RTCIceCandidate``](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate/toJSON).
-    ///
-    /// When PeerSignal itself is JSON serialized, that results in JSON data as a string inside of
-    /// another JSON string: this is inefficient. Storing this as a string here also reduces type
-    /// safety and clarity at this layer. It may be preferable to instead include the structured
-    /// data here as more specific Rust types, but this would be a breaking protocol change, and
-    /// would only offer small benefits.
+    // JSON encoding of an [`RTCIceCandidate`](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate).
+    //
+    // Note that while [`RTCIceCandidate`](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate/RTCIceCandidate)'s
+    // constructor accepts a string for legacy purposes, that is not how this is being used: this
+    // is instead a
+    // [JSON encoding of the of the `RTCIceCandidate`](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate/toJSON).
+    //
+    // When PeerSignal itself is JSON serialized, that results in JSON data as a string inside of
+    // another JSON string: this is inefficient (but negligibly so) and reduces type safety.
+    // It may be preferable refactor the abstraction implemented by the native and wasm sockets to
+    // have a with a more specific type instead of this to deduplicate their encoding logic
+    // and help ensure they are well aligned and can interoperate.
     IceCandidate(String),
     /// Offer a handshake.
     ///

--- a/matchbox_socket/src/webrtc_socket/messages.rs
+++ b/matchbox_socket/src/webrtc_socket/messages.rs
@@ -1,18 +1,44 @@
+//! Messages involved in the "signaling" process.
+//!
+//! These messages involve the signaling server and are used to establish the direct peer to peer
+//! connections.
+//! The direct peer to peer messages do not use these types: they use [`crate::Packet`].
+
 use serde::{Deserialize, Serialize};
 
-/// Events go from signaling server to peer
+/// Events which go from signaling server to peer.
 pub type PeerEvent = matchbox_protocol::PeerEvent<PeerSignal>;
 
-/// Requests go from peer to signaling server
+/// Requests which go from peer to signaling server.
 pub type PeerRequest = matchbox_protocol::PeerRequest<PeerSignal>;
 
-/// Signals go from peer to peer via the signaling server
+/// Signals which go from peer to peer via the signaling server.
+///
+/// Wrapped by [`PeerRequest::Signal`] on the way to the signaling server,
+/// and [`PeerEvent::Signal`] on the from the signalizing server the other peer.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub enum PeerSignal {
-    /// Ice Candidate
+    /// [Ice (Interactive Connectivity Establishment) Candidate](https://en.wikipedia.org/wiki/Interactive_Connectivity_Establishment).
+    ///
+    /// JSON encoding of an [`RTCIceCandidate`](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate).
+    ///
+    /// Note that while [`RTCIceCandidate`](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate/RTCIceCandidate)'s
+    /// constructor accepts a string for legacy purposes, that is not how this is being used: this
+    /// is instead a
+    /// [JSON encoding of the of the `RTCIceCandidate``](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate/toJSON).
+    ///
+    /// When PeerSignal itself is JSON serialized, that results in JSON data as a string inside of
+    /// another JSON string: this is inefficient. Storing this as a string here also reduces type
+    /// safety and clarity at this layer. It may be preferable to instead include the structured
+    /// data here as more specific Rust types, but this would be a breaking protocol change, and
+    /// would only offer small benefits.
     IceCandidate(String),
-    /// Offer
+    /// Offer a handshake.
+    ///
+    /// The contained string is the [`sdp`](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/createOffer#sdp).
     Offer(String),
-    /// Answer
+    /// Answer accepting a handshake.
+    ///
+    /// The contained string is the [`sdp`](https://developer.mozilla.org/en-US/docs/Web/API/RTCSessionDescription/sdp).
     Answer(String),
 }


### PR DESCRIPTION
Previously it was not particularly clear that nothing in messages.ts was used for actual peer to peer messages, and its specific to signaling. I have added some top level docs to make this clear, and filling in the lower level docs to make it clear what the content of the various strings are.

These details were determined by inspecting the code. If there is an intention for this to be more general than how the current native and wasm implementation use them, then these detail might be wrong, but I think the intention is that these always contain the strings as I have described them.